### PR TITLE
fix signal bug in Redis/Nginx

### DIFF
--- a/apps/c/nginx/features.txt
+++ b/apps/c/nginx/features.txt
@@ -11,3 +11,4 @@ epoll
 poll
 select
 rtc
+signal

--- a/apps/c/redis/features.txt
+++ b/apps/c/redis/features.txt
@@ -11,3 +11,4 @@ epoll
 poll
 virtio-9p
 rtc
+signal


### PR DESCRIPTION
Since wasm PR #40 adds `signal` feature in `ruxmusl`, signal-related APIs are not accessible if `signal` feature is not specified in Redis/Nginx, which may cause unknown bugs. 
This PR just adds `signal` feature in these two apps.