### PR TITLE
using cmake to build WAMR

### DIFF
--- a/apps/c/wamr/CMakeLists.txt
+++ b/apps/c/wamr/CMakeLists.txt
@@ -1,0 +1,175 @@
+# Copyright (C) 2019 Intel Corporation.  All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+cmake_minimum_required (VERSION 3.14)
+
+set (CMAKE_C_COMPILER "aarch64-linux-musl-gcc")
+set (CMAKE_CXX_COMPILER "aarch64-linux-musl-g++")
+set (CMAKE_AR "aarch64-linux-musl-ar" CACHE FILEPATH "" FORCE)
+set (CMAKE_RANLIB "aarch64-linux-musl-ranlib")
+
+include(CheckPIESupported)
+
+project (iwasm)
+
+set (CMAKE_VERBOSE_MAKEFILE OFF)
+
+set (WAMR_BUILD_PLATFORM "linux")
+
+# Reset default linker flags
+set (CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
+set (CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS "")
+
+set (CMAKE_C_STANDARD 99)
+set (CMAKE_CXX_STANDARD 17)
+
+# Set WAMR_BUILD_TARGET, currently values supported:
+# "X86_64", "AMD_64", "X86_32", "AARCH64[sub]", "ARM[sub]", "THUMB[sub]",
+# "MIPS", "XTENSA", "RISCV64[sub]", "RISCV32[sub]"
+if (NOT DEFINED WAMR_BUILD_TARGET)
+  if (CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm64|aarch64)")
+    set (WAMR_BUILD_TARGET "AARCH64")
+  elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL "riscv64")
+    set (WAMR_BUILD_TARGET "RISCV64")
+  elseif (CMAKE_SIZEOF_VOID_P EQUAL 8)
+    # Build as X86_64 by default in 64-bit platform
+    set (WAMR_BUILD_TARGET "X86_64")
+  elseif (CMAKE_SIZEOF_VOID_P EQUAL 4)
+    # Build as X86_32 by default in 32-bit platform
+    set (WAMR_BUILD_TARGET "X86_32")
+  else ()
+    message(SEND_ERROR "Unsupported build target platform!")
+  endif ()
+endif ()
+
+if (NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release)
+endif ()
+
+if (NOT DEFINED WAMR_BUILD_INTERP)
+  # Enable Interpreter by default
+  set (WAMR_BUILD_INTERP 1)
+endif ()
+
+if (NOT DEFINED WAMR_BUILD_AOT)
+  # Enable AOT by default.
+  set (WAMR_BUILD_AOT 1)
+endif ()
+
+if (NOT DEFINED WAMR_BUILD_JIT)
+  # Disable JIT by default.
+  set (WAMR_BUILD_JIT 0)
+endif ()
+
+if (NOT DEFINED WAMR_BUILD_FAST_JIT)
+  # Disable Fast JIT by default
+  set (WAMR_BUILD_FAST_JIT 0)
+endif ()
+
+if (NOT DEFINED WAMR_BUILD_LIBC_BUILTIN)
+  # Enable libc builtin support by default
+  set (WAMR_BUILD_LIBC_BUILTIN 1)
+endif ()
+
+if (NOT DEFINED WAMR_BUILD_LIBC_WASI)
+  # Enable libc wasi support by default
+  set (WAMR_BUILD_LIBC_WASI 1)
+endif ()
+
+if (NOT DEFINED WAMR_BUILD_FAST_INTERP)
+  # Enable fast interpreter
+  set (WAMR_BUILD_FAST_INTERP 1)
+endif ()
+
+if (NOT DEFINED WAMR_BUILD_MULTI_MODULE)
+  # Disable multiple modules by default
+  set (WAMR_BUILD_MULTI_MODULE 0)
+endif ()
+
+if (NOT DEFINED WAMR_BUILD_LIB_PTHREAD)
+  # Disable pthread library by default
+  set (WAMR_BUILD_LIB_PTHREAD 0)
+endif ()
+
+if (NOT DEFINED WAMR_BUILD_LIB_WASI_THREADS)
+  # Disable wasi threads library by default
+  set (WAMR_BUILD_LIB_WASI_THREADS 0)
+endif()
+
+
+if (NOT DEFINED WAMR_BUILD_MINI_LOADER)
+  # Disable wasm mini loader by default
+  set (WAMR_BUILD_MINI_LOADER 0)
+endif ()
+
+if (NOT DEFINED WAMR_BUILD_SIMD)
+  # Enable SIMD by default
+  set (WAMR_BUILD_SIMD 1)
+endif ()
+
+if (NOT DEFINED WAMR_BUILD_REF_TYPES)
+  # Disable reference types by default
+  set (WAMR_BUILD_REF_TYPES 0)
+endif ()
+
+if (NOT DEFINED WAMR_BUILD_DEBUG_INTERP)
+  # Disable Debug feature by default
+  set (WAMR_BUILD_DEBUG_INTERP 0)
+endif ()
+
+if (WAMR_BUILD_DEBUG_INTERP EQUAL 1)
+  set (WAMR_BUILD_FAST_INTERP 0)
+  set (WAMR_BUILD_MINI_LOADER 0)
+  set (WAMR_BUILD_SIMD 0)
+endif ()
+
+set (WAMR_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
+
+include (${WAMR_ROOT_DIR}/build-scripts/runtime_lib.cmake)
+
+check_pie_supported()
+# add_library(vmlib ${WAMR_RUNTIME_LIB_SOURCE})
+# set_target_properties (vmlib PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gc-sections")
+
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wformat -Wformat-security -Wshadow")
+# set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wconversion -Wsign-conversion")
+
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wformat -Wformat-security -Wno-unused")
+
+# if (WAMR_BUILD_TARGET MATCHES "X86_.*" OR WAMR_BUILD_TARGET STREQUAL "AMD_64")
+#   if (NOT (CMAKE_C_COMPILER MATCHES ".*clang.*" OR CMAKE_C_COMPILER_ID MATCHES ".*Clang"))
+#     set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mindirect-branch-register")
+#     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mindirect-branch-register")
+#     # UNDEFINED BEHAVIOR, refer to https://en.cppreference.com/w/cpp/language/ub
+#   endif ()
+# endif ()
+
+# The following flags are to enhance security, but it may impact performance,
+# we disable them by default.
+#if (WAMR_BUILD_TARGET MATCHES "X86_.*" OR WAMR_BUILD_TARGET STREQUAL "AMD_64")
+#  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ftrapv -D_FORTIFY_SOURCE=2")
+#endif ()
+#set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fstack-protector-strong --param ssp-buffer-size=4")
+#set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wl,-z,noexecstack,-z,relro,-z,now")
+
+include (${SHARED_DIR}/utils/uncommon/shared_uncommon.cmake)
+
+add_library (iwasm main.c ${UNCOMMON_SHARED_SOURCE} ${WAMR_RUNTIME_LIB_SOURCE})
+
+set_target_properties (iwasm PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+install (TARGETS iwasm DESTINATION bin)
+
+target_link_libraries (iwasm ${WAMR_RUNTIME_LIB_SOURCE} ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS} ${WASI_NN_LIBS})
+
+# add_library (libiwasm SHARED ${WAMR_RUNTIME_LIB_SOURCE})
+
+# install (TARGETS libiwasm DESTINATION lib)
+
+# set_target_properties (libiwasm PROPERTIES OUTPUT_NAME iwasm)
+
+# target_link_libraries (libiwasm ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS} ${WASI_NN_LIBS} -lm -ldl -lpthread)
+
+

--- a/apps/c/wamr/README.md
+++ b/apps/c/wamr/README.md
@@ -7,6 +7,8 @@ The `main.wasm` and other wasm files is compiled from `.c` files in `rootfs/` us
 
 # How to build?
 
+The compilation of `WAMR` depends on `cmake`.
+
 Take the 2048 game as an example. To run 2048, you need to compile the `2048.wasm` wasm file first.
 
 We use `wasi-sdk` to compile the `2048` wasm file. You can download the `wasi-sdk` from [here](https://github.com/WebAssembly/wasi-sdk). Or you can use other wasm compiler.

--- a/apps/c/wamr/axbuild.mk
+++ b/apps/c/wamr/axbuild.mk
@@ -1,95 +1,14 @@
 wamr-version := 6dbfeb25dd164c0ffcec21806e1c1cd0dff27c58
 wamr-dir := $(APP)/wasm-micro-runtime-$(wamr-version)
 
+CMAKE = cmake
+
+ARCH ?= x86_64
+ARCH_UPPER ?= $(shell echo $(ARCH) | tr '[a-z]' '[A-Z]')
+
 app-objs := wamr.o
-
-LIBWAMR_SRC := $(wamr-dir)
-LIBWAMR_BASE := $(APP)
-
-# TODO: -mindirect-branch-register is only needed for x86_64
-WAMR_C_FLAGS = -fno-builtin -ffreestanding -std=gnu99 -ffunction-sections -fdata-sections -Wall -Wno-unused-parameter -Wno-pedantic -fPIC -Wall -Wextra -Wformat -Wformat-security -Wshadow -O3 -DNDEBUG -fPIE
-WAMR_ASM_FLAGS = -fno-builtin -ffreestanding -O3 -DNDEBUG -fPIC
-
-WAMR_C_DEFINES = -DBUILD_TARGET_AARCH64  -DBH_FREE=wasm_runtime_free -DBH_MALLOC=wasm_runtime_malloc -DBH_PLATFORM_LINUX -DWASM_DISABLE_HW_BOUND_CHECK=1 -DWASM_DISABLE_STACK_HW_BOUND_CHECK=1 -DWASM_DISABLE_WAKEUP_BLOCKING_OP=1 -DWASM_DISABLE_WRITE_GS_BASE=1 -DWASM_ENABLE_AOT=1 -DWASM_ENABLE_BULK_MEMORY=1 -DWASM_ENABLE_FAST_INTERP=1 -DWASM_ENABLE_INTERP=1 -DWASM_ENABLE_LIBC_BUILTIN=1 -DWASM_ENABLE_LIBC_WASI=1 -DWASM_ENABLE_MINI_LOADER=0 -DWASM_ENABLE_MODULE_INST_CONTEXT=1 -DWASM_ENABLE_MULTI_MODULE=0 -DWASM_ENABLE_SHARED_MEMORY=0 -DWASM_ENABLE_SIMD=1
-# WAMR_C_DEFINES = -DBUILD_TARGET_AARCH64 -DBH_FREE=wasm_runtime_free -DBH_MALLOC=wasm_runtime_malloc -DBH_PLATFORM_LINUX -DWASM_DISABLE_HW_BOUND_CHECK=0 -DWASM_DISABLE_STACK_HW_BOUND_CHECK=0 -DWASM_DISABLE_WAKEUP_BLOCKING_OP=0 -DWASM_DISABLE_WRITE_GS_BASE=1 -DWASM_ENABLE_AOT=1 -DWASM_ENABLE_BULK_MEMORY=1 -DWASM_ENABLE_FAST_INTERP=1 -DWASM_ENABLE_INTERP=1 -DWASM_ENABLE_LIBC_BUILTIN=1 -DWASM_ENABLE_LIBC_WASI=1 -DWASM_ENABLE_MINI_LOADER=0 -DWASM_ENABLE_MODULE_INST_CONTEXT=1 -DWASM_ENABLE_MULTI_MODULE=0 -DWASM_ENABLE_SHARED_MEMORY=0 -DWASM_ENABLE_SIMD=1
-
-C_INCLUDES = -I${LIBWAMR_SRC}/core/iwasm/interpreter \
-				-I${LIBWAMR_SRC}/core/iwasm/aot \
-				-I${LIBWAMR_SRC}/core/iwasm/libraries/libc-builtin \
-				-I${LIBWAMR_SRC}/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/include \
-				-I${LIBWAMR_SRC}/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src \
-				-I${LIBWAMR_SRC}/product-mini/platforms/linux/../../../core/iwasm/include \
-				-I${LIBWAMR_SRC}/core/shared/platform/linux \
-				-I${LIBWAMR_SRC}/core/shared/platform/linux/../include \
-				-I${LIBWAMR_SRC}/core/shared/platform/common/libc-util \
-				-I${LIBWAMR_SRC}/core/shared/mem-alloc \
-				-I${LIBWAMR_SRC}/core/iwasm/common \
-				-I${LIBWAMR_SRC}/core/shared/utils \
-				-I${LIBWAMR_SRC}/core/shared/utils/uncommon
-
-platform_src := $(LIBWAMR_SRC)/core/shared/platform/linux/platform_init.c \
-				$(LIBWAMR_SRC)/core/shared/platform/common/posix/posix_blocking_op.c \
-				$(LIBWAMR_SRC)/core/shared/platform/common/posix/posix_clock.c       \
-				$(LIBWAMR_SRC)/core/shared/platform/common/posix/posix_file.c        \
-				$(LIBWAMR_SRC)/core/shared/platform/common/posix/posix_malloc.c      \
-				$(LIBWAMR_SRC)/core/shared/platform/common/posix/posix_memmap.c      \
-				$(LIBWAMR_SRC)/core/shared/platform/common/posix/posix_sleep.c       \
-				$(LIBWAMR_SRC)/core/shared/platform/common/posix/posix_socket.c      \
-				$(LIBWAMR_SRC)/core/shared/platform/common/posix/posix_thread.c      \
-				$(LIBWAMR_SRC)/core/shared/platform/common/posix/posix_time.c        \
-				$(LIBWAMR_SRC)/core/shared/platform/common/libc-util/libc_errno.c
-
-mem_alloc_src := $(LIBWAMR_SRC)/core/shared/mem-alloc/ems/ems_alloc.c \
-				 $(LIBWAMR_SRC)/core/shared/mem-alloc/ems/ems_hmu.c   \
-				 $(LIBWAMR_SRC)/core/shared/mem-alloc/ems/ems_kfc.c   \
-				 $(LIBWAMR_SRC)/core/shared/mem-alloc/mem_alloc.c
-
-utils_src := $(LIBWAMR_SRC)/core/shared/utils/bh_assert.c		\
-				$(LIBWAMR_SRC)/core/shared/utils/bh_bitmap.c         \
-				$(LIBWAMR_SRC)/core/shared/utils/bh_common.c         \
-				$(LIBWAMR_SRC)/core/shared/utils/bh_hashmap.c        \
-				$(LIBWAMR_SRC)/core/shared/utils/bh_list.c           \
-				$(LIBWAMR_SRC)/core/shared/utils/bh_log.c            \
-				$(LIBWAMR_SRC)/core/shared/utils/bh_queue.c          \
-				$(LIBWAMR_SRC)/core/shared/utils/bh_vector.c         \
-				$(LIBWAMR_SRC)/core/shared/utils/runtime_timer.c
-
-libc_builtin_src := $(LIBWAMR_SRC)/core/iwasm/libraries/libc-builtin/libc_builtin_wrapper.c
-
-libc_wasi_src := $(LIBWAMR_SRC)/core/iwasm/libraries/libc-wasi/libc_wasi_wrapper.c \
-					$(LIBWAMR_SRC)/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/blocking_op.c\
-					$(LIBWAMR_SRC)/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c   \
-					$(LIBWAMR_SRC)/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/random.c  \
-					$(LIBWAMR_SRC)/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/str.c
-
-iwasm_common_src := $(LIBWAMR_SRC)/core/iwasm/common/wasm_application.c \
-					$(LIBWAMR_SRC)/core/iwasm/common/wasm_blocking_op.c \
-					$(LIBWAMR_SRC)/core/iwasm/common/wasm_c_api.c \
-					$(LIBWAMR_SRC)/core/iwasm/common/wasm_exec_env.c \
-					$(LIBWAMR_SRC)/core/iwasm/common/wasm_memory.c \
-					$(LIBWAMR_SRC)/core/iwasm/common/wasm_native.c \
-					$(LIBWAMR_SRC)/core/iwasm/common/wasm_runtime_common.c \
-					$(LIBWAMR_SRC)/core/iwasm/common/wasm_shared_memory.c
-iwasm_common_src_s := $(LIBWAMR_SRC)/core/iwasm/common/arch/invokeNative_aarch64_simd.s
-
-iwasm_interp_src := $(LIBWAMR_SRC)/core/iwasm/interpreter/wasm_interp_fast.c \
-					$(LIBWAMR_SRC)/core/iwasm/interpreter/wasm_loader.c \
-					$(LIBWAMR_SRC)/core/iwasm/interpreter/wasm_runtime.c
-
-iwasm_aot_src := $(LIBWAMR_SRC)/core/iwasm/aot/aot_intrinsic.c \
-					$(LIBWAMR_SRC)/core/iwasm/aot/aot_loader.c \
-					$(LIBWAMR_SRC)/core/iwasm/aot/aot_runtime.c \
-					$(LIBWAMR_SRC)/core/iwasm/aot/arch/aot_reloc_x86_64.c
-
-LIBWAMR_SRCS := $(platform_src) $(mem_alloc_src) $(utils_src) $(libc_builtin_src) $(libc_wasi_src) $(iwasm_common_src) $(iwasm_interp_src) $(iwasm_aot_src)
-LIBWAMR_SRCS_s := $(iwasm_common_src_s)
-
-LIBWAMR_SRCS += $(LIBWAMR_SRC)/product-mini/platforms/linux/main.c
-LIBWAMR_SRCS += $(LIBWAMR_SRC)/core/shared/utils/uncommon/bh_getopt.c
-LIBWAMR_SRCS += $(LIBWAMR_SRC)/core/shared/utils/uncommon/bh_read_file.c
-
-objs := $(LIBWAMR_SRCS:.c=.o)
-objs_s := $(LIBWAMR_SRCS_s:.s=.o)
+wamr_product_dir = $(wamr-dir)/product-mini/platforms/ruxos
+wamr_product_build = $(wamr_product_dir)/build
 
 $(wamr-dir):
 	@echo "Download wamr source code"
@@ -100,17 +19,13 @@ $(wamr-dir):
 
 $(APP)/$(app-objs): build_wamr
 
-$(objs_s): %.o: %.s
-	$(call run_cmd, $(CC), $(WAMR_C_DEFINES) $(C_INCLUDES) $(WAMR_ASM_FLAGS) -c -o $@ $<)
-
-$(objs): %.o: %.c $(LIBWAMR_SRC)/product-mini/platforms/posix/main.c
-	$(call run_cmd, $(CC), $(WAMR_C_DEFINES) $(C_INCLUDES) $(WAMR_C_FLAGS) -c -o $@ $<)
-
-build_wamr: $(wamr-dir) $(objs) $(objs_s)
-# -r means relocatable
-	$(call run_cmd, $(LD), $(LDFLAGS) -r -e main $(objs) $(objs_s) -o $(app-objs))
+build_wamr: $(wamr-dir) $(APP)/axbuild.mk
+	mkdir -p $(wamr_product_dir) && cp -r $(wamr_product_dir)/../linux/* $(wamr_product_dir) && cp $(APP)/CMakeLists.txt $(wamr_product_dir)
+	cd $(wamr_product_dir) && mkdir -p build && cd build && $(CMAKE) .. -DWAMR_BUILD_TARGET=$(ARCH_UPPER) -DWAMR_DISABLE_HW_BOUND_CHECK=1 && $(MAKE)
+	cp $(wamr_product_build)/libiwasm.a $(app-objs)
 
 clean_c::
-	rm -f $(objs) $(objs_s)
+	rm -rf $(wamr_product_build)
+	rm -f $(APP)/$(app-objs)
 
 .PHONY: build_wamr clean_c

--- a/apps/c/wamr/wamr.patch
+++ b/apps/c/wamr/wamr.patch
@@ -12,3 +12,25 @@
          return;
      }
  #endif
+
+--- /core/shared/platform/common/posix/posix_memmap.c
++++ /core/shared/platform/common/posix/posix_memmap.c
+@@ -76,12 +76,12 @@ os_mmap(void *hint, size_t size, int prot, int flags, os_file_handle file)
+     if (prot & MMAP_PROT_EXEC)
+         map_prot |= PROT_EXEC;
+ 
+-#if defined(BUILD_TARGET_X86_64) || defined(BUILD_TARGET_AMD_64)
+-#ifndef __APPLE__
+-    if (flags & MMAP_MAP_32BIT)
+-        map_flags |= MAP_32BIT;
+-#endif
+-#endif
++    // #if defined(BUILD_TARGET_X86_64) || defined(BUILD_TARGET_AMD_64)
++    // #ifndef __APPLE__
++    //     if (flags & MMAP_MAP_32BIT)
++    //         map_flags |= MAP_32BIT;
++    // #endif
++    // #endif
+ 
+     if (flags & MMAP_MAP_FIXED)
+         map_flags |= MAP_FIXED;


### PR DESCRIPTION
I have built WAMR through cmake, instead of specifying each source file manually.

Users can configure some options using -D in cmake command, which makes it convenient to select optional function of WAMR.

It is the basis for the next step of adding support for WASI-NN.