### PR TITLE
Add x86-musl support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1570,6 +1570,7 @@ name = "ruxmusl"
 version = "0.1.0"
 dependencies = [
  "axlog",
+ "cfg-if",
  "crate_interface",
  "kernel_guard",
  "num_enum",

--- a/api/ruxos_posix_api/src/imp/io_mpx/poll.rs
+++ b/api/ruxos_posix_api/src/imp/io_mpx/poll.rs
@@ -58,7 +58,7 @@ pub unsafe fn sys_ppoll(
 pub unsafe fn sys_poll(fds: *mut ctypes::pollfd, nfds: ctypes::nfds_t, timeout: c_int) -> c_int {
     debug!("sys_poll <= nfds: {} timeout: {} ms", nfds, timeout);
 
-    syscall_body!(ax_poll, {
+    syscall_body!(sys_poll, {
         if nfds == 0 {
             return Err(LinuxError::EINVAL);
         }

--- a/api/ruxos_posix_api/src/imp/mmap.rs
+++ b/api/ruxos_posix_api/src/imp/mmap.rs
@@ -72,7 +72,7 @@ pub fn sys_mprotect(addr: *mut c_void, len: ctypes::size_t, prot: c_int) -> c_in
 
 /// Remap a virtual memory address
 ///
-/// TODO: only support
+/// TODO: null implementation
 pub fn sys_mremap(
     old_addr: *mut c_void,
     old_size: ctypes::size_t,
@@ -84,24 +84,17 @@ pub fn sys_mremap(
         "sys_mremap <= old_addr: {:p}, old_size: {}, new_size: {}, flags: {}, new_addr: {:p}",
         old_addr, old_size, new_size, _flags, _new_addr
     );
-    syscall_body!(sys_mremap, {
-        if old_addr.is_null() {
-            // TODO: It should be ctypes::MAP_FAILED,
-            // but it is not defined in ctypes for an unknown reason
-            return Ok(-1 as _);
-        }
-        Ok::<*mut c_void, LinuxError>(-1 as _)
-    })
+    syscall_body!(sys_mremap, Ok::<*mut c_void, LinuxError>(-1 as _))
 }
 
 /// give advice about use of memory
 /// if success return 0, if error return -1
 ///
 /// TODO: implement this
-pub fn sys_madvice(addr: *mut c_void, len: ctypes::size_t, advice: c_int) -> c_int {
+pub fn sys_madvise(addr: *mut c_void, len: ctypes::size_t, advice: c_int) -> c_int {
     debug!(
-        "sys_madvice <= addr: {:p}, len: {}, advice: {}",
+        "sys_madvise <= addr: {:p}, len: {}, advice: {}",
         addr, len, advice
     );
-    syscall_body!(sys_madvice, Ok(0))
+    syscall_body!(sys_madvise, Ok(0))
 }

--- a/api/ruxos_posix_api/src/imp/mod.rs
+++ b/api/ruxos_posix_api/src/imp/mod.rs
@@ -10,6 +10,7 @@
 mod stdio;
 
 pub mod io;
+pub mod prctl;
 pub mod resources;
 pub mod rt_sig;
 pub mod stat;

--- a/api/ruxos_posix_api/src/imp/prctl.rs
+++ b/api/ruxos_posix_api/src/imp/prctl.rs
@@ -1,0 +1,39 @@
+/* Copyright (c) [2023] [Syswonder Community]
+ *   [Ruxos] is licensed under Mulan PSL v2.
+ *   You can use this software according to the terms and conditions of the Mulan PSL v2.
+ *   You may obtain a copy of Mulan PSL v2 at:
+ *               http://license.coscl.org.cn/MulanPSL2
+ *   THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ *   See the Mulan PSL v2 for more details.
+ */
+
+use core::ffi::{c_int, c_ulong};
+
+use axerrno::LinuxError;
+
+const ARCH_SET_FS: i32 = 0x1002;
+
+/// set thread state
+pub fn sys_arch_prctl(code: c_int, addr: c_ulong) -> c_int {
+    debug!("sys_arch_prctl <= code: {}, addr: {:#x}", code, addr);
+    syscall_body!(sys_arch_prctl, {
+        match code {
+            ARCH_SET_FS => {
+                unsafe {
+                    ruxhal::arch::write_thread_pointer(addr as _);
+                }
+                Ok(0)
+            }
+            _ => Err(LinuxError::EINVAL),
+        }
+    })
+}
+
+/// TODO: fake implementation for prctl
+pub fn sys_prctl(op: c_int, arg0: c_ulong, arg1: c_ulong, arg2: c_ulong, arg3: c_ulong) -> c_int {
+    debug!(
+        "sys_prctl <= op: {}, arg0: {}, arg1: {}, arg2: {}, arg3: {}",
+        op, arg0, arg1, arg2, arg3
+    );
+    syscall_body!(sys_prctl, Ok(0))
+}

--- a/api/ruxos_posix_api/src/imp/pthread/futex.rs
+++ b/api/ruxos_posix_api/src/imp/pthread/futex.rs
@@ -17,6 +17,7 @@ use ruxtask::{current, AxTaskRef, TaskState, WaitQueue};
 
 use crate::ctypes;
 
+#[derive(Debug)]
 enum FutexFlags {
     Wait,
     Wake,
@@ -59,7 +60,7 @@ pub fn sys_futex(
     check_dead_wait();
     let flag = FutexFlags::from(op);
     let current_task = current();
-    let timeout = if to != 0 {
+    let timeout = if to != 0 && to > 0xffff000000000000usize {
         let dur = unsafe { Duration::from(*(to as *const ctypes::timespec)) };
         dur.as_nanos() as u64
     } else {

--- a/api/ruxos_posix_api/src/imp/time.rs
+++ b/api/ruxos_posix_api/src/imp/time.rs
@@ -58,7 +58,7 @@ pub unsafe fn sys_clock_gettime(_clk: ctypes::clockid_t, ts: *mut ctypes::timesp
 }
 
 /// Get clock time since booting
-pub unsafe fn sys_clock_settime(_clk: ctypes::clockid_t, ts: *mut ctypes::timespec) -> c_int {
+pub unsafe fn sys_clock_settime(_clk: ctypes::clockid_t, ts: *const ctypes::timespec) -> c_int {
     syscall_body!(sys_clock_setttime, {
         if ts.is_null() {
             return Err(LinuxError::EFAULT);
@@ -108,4 +108,10 @@ pub unsafe fn sys_nanosleep(req: *const ctypes::timespec, rem: *mut ctypes::time
         }
         Ok(0)
     })
+}
+
+/// Get time of the day, ignore second parameter
+pub unsafe fn sys_gettimeofday(ts: *mut ctypes::timespec, flags: c_int) -> c_int {
+    debug!("sys_gettimeofday <= flags: {}", flags);
+    unsafe { sys_clock_gettime(0, ts) }
 }

--- a/api/ruxos_posix_api/src/lib.rs
+++ b/api/ruxos_posix_api/src/lib.rs
@@ -46,13 +46,14 @@ pub mod config {
 pub mod ctypes;
 
 pub use imp::io::{sys_read, sys_readv, sys_write, sys_writev};
+pub use imp::prctl::{sys_arch_prctl, sys_prctl};
 pub use imp::resources::{sys_getrlimit, sys_prlimit64, sys_setrlimit};
 pub use imp::rt_sig::{sys_rt_sigaction, sys_rt_sigprocmask};
 pub use imp::stat::{sys_getegid, sys_geteuid, sys_umask};
 pub use imp::sys::{sys_sysinfo, sys_uname};
 pub use imp::sys_invalid;
 pub use imp::task::{sys_exit, sys_getpid, sys_sched_yield};
-pub use imp::time::{sys_clock_gettime, sys_clock_settime, sys_nanosleep};
+pub use imp::time::{sys_clock_gettime, sys_clock_settime, sys_gettimeofday, sys_nanosleep};
 
 #[cfg(all(feature = "fd", feature = "musl"))]
 pub use imp::fd_ops::sys_dup3;
@@ -73,7 +74,7 @@ pub use imp::io_mpx::{sys_pselect6, sys_select};
 #[cfg(feature = "fd")]
 pub use imp::ioctl::sys_ioctl;
 #[cfg(feature = "alloc")]
-pub use imp::mmap::{sys_madvice, sys_mmap, sys_mprotect, sys_mremap, sys_munmap};
+pub use imp::mmap::{sys_madvise, sys_mmap, sys_mprotect, sys_mremap, sys_munmap};
 #[cfg(feature = "net")]
 pub use imp::net::{
     sys_accept, sys_bind, sys_connect, sys_freeaddrinfo, sys_getaddrinfo, sys_getpeername,
@@ -102,7 +103,13 @@ pub use imp::signal::{sys_getitimer, sys_setitimer, sys_sigaction, sys_sigaltsta
 
 #[cfg(feature = "multitask")]
 pub use imp::pthread::futex::sys_futex;
+#[cfg(all(
+    feature = "multitask",
+    feature = "musl",
+    any(target_arch = "aarch64", target_arch = "x86_64")
+))]
+pub use imp::pthread::sys_clone;
 #[cfg(all(feature = "multitask", feature = "musl"))]
-pub use imp::pthread::{sys_clone, sys_set_tid_address};
+pub use imp::pthread::sys_set_tid_address;
 #[cfg(feature = "multitask")]
 pub use imp::pthread::{sys_pthread_create, sys_pthread_exit, sys_pthread_join, sys_pthread_self};

--- a/modules/ruxfs/src/mounts.rs
+++ b/modules/ruxfs/src/mounts.rs
@@ -124,7 +124,7 @@ pub(crate) fn etcfs() -> VfsResult<Arc<fs::ramfs::RamFileSystem>> {
     // Create /etc/localtime
     etc_root.create("localtime", VfsNodeType::File)?;
 
-    // Createe /etc/hosts
+    // Create /etc/hosts
     etc_root.create("hosts", VfsNodeType::File)?;
     let file_hosts = etc_root.clone().lookup("hosts")?;
     file_hosts.write_at(
@@ -136,6 +136,17 @@ pub(crate) fn etcfs() -> VfsResult<Arc<fs::ramfs::RamFileSystem>> {
         ff02::1 ip6-allnodes \n\
         ff02::2 ip6-allrouters \n\
         ff02::3 ip6-allhosts\n",
+    )?;
+
+    // Create /etc/resolv.conf
+    etc_root.create("resolv.conf", VfsNodeType::File)?;
+    let file_resolv = etc_root.clone().lookup("resolv.conf")?;
+    file_resolv.write_at(
+        0,
+        b"nameserver 127.0.0.53\n\
+        options edns0 trust-ad\n\
+        search lan\n
+        ",
     )?;
 
     Ok(Arc::new(etcfs))

--- a/modules/ruxhal/src/arch/x86_64/mod.rs
+++ b/modules/ruxhal/src/arch/x86_64/mod.rs
@@ -19,6 +19,7 @@ use core::arch::asm;
 use memory_addr::{PhysAddr, VirtAddr};
 use x86::{controlregs, msr, tlb};
 use x86_64::instructions::interrupts;
+use x86_64::registers::model_specific::EferFlags;
 
 pub use self::context::{ExtendedState, FxsaveArea, TaskContext, TrapFrame};
 pub use self::gdt::GdtStruct;
@@ -116,4 +117,42 @@ pub fn read_thread_pointer() -> usize {
 #[inline]
 pub unsafe fn write_thread_pointer(fs_base: usize) {
     unsafe { msr::wrmsr(msr::IA32_FS_BASE, fs_base as u64) }
+}
+
+#[cfg(feature = "musl")]
+core::arch::global_asm!(include_str!("syscall.S"),);
+
+/// Set syscall entry
+///
+/// # Safety
+///
+/// This function modify MSR registers
+#[cfg(feature = "musl")]
+#[inline]
+pub unsafe fn init_syscall_entry() {
+    extern "C" {
+        fn x86_syscall_entry();
+    }
+
+    let cpuid = raw_cpuid::CpuId::new();
+
+    unsafe {
+        assert!(cpuid
+            .get_extended_processor_and_feature_identifiers()
+            .unwrap()
+            .has_syscall_sysret());
+
+        x86_64::registers::model_specific::LStar::write(x86_64::VirtAddr::new(
+            x86_syscall_entry as usize as u64,
+        ));
+        x86_64::registers::model_specific::Efer::update(|efer| {
+            efer.insert(
+                EferFlags::SYSTEM_CALL_EXTENSIONS
+                    | EferFlags::LONG_MODE_ACTIVE
+                    | EferFlags::LONG_MODE_ENABLE,
+            );
+        });
+        msr::wrmsr(msr::IA32_STAR, (0x10 << 48) | (0x10 << 32));
+        msr::wrmsr(msr::IA32_FMASK, 0x47700);
+    }
 }

--- a/modules/ruxhal/src/arch/x86_64/syscall.S
+++ b/modules/ruxhal/src/arch/x86_64/syscall.S
@@ -1,0 +1,57 @@
+
+.section .text
+.code64
+.global x86_syscall_entry
+x86_syscall_entry:
+
+    push    r15
+    push    r14
+    push    r13
+    push    r12
+    push    r11
+    push    r10
+    push    r9
+    push    r8
+    push    rdi
+    push    rsi
+    push    rbp
+    push    rbx
+    push    rdx
+    push    rcx
+
+    mov     rcx, r10
+
+    sub     rsp, 8
+    mov     [rsp], r9
+
+    mov     r9, r8
+    mov     r8, rcx
+    mov     rcx, rdx
+    mov     rdx, rsi
+    mov     rsi, rdi
+    mov     rdi, rax
+
+    call    x86_syscall_handler
+
+    add     rsp, 8
+
+    pop     rcx
+    pop     rdx
+    pop     rbx
+    pop     rbp
+    pop     rsi
+    pop     rdi
+    pop     r8
+    pop     r9
+    pop     r10
+    pop     r11
+    pop     r12
+    pop     r13
+    pop     r14
+    pop     r15
+
+    # restore rflags
+    push    r11
+    popfq
+
+    jmp     rcx

--- a/modules/ruxhal/src/arch/x86_64/trap.rs
+++ b/modules/ruxhal/src/arch/x86_64/trap.rs
@@ -53,3 +53,22 @@ fn x86_trap_handler(tf: &TrapFrame) {
         }
     }
 }
+
+#[cfg(feature = "musl")]
+#[no_mangle]
+fn x86_syscall_handler(
+    syscall_id: usize,
+    arg1: usize,
+    arg2: usize,
+    arg3: usize,
+    arg4: usize,
+    arg5: usize,
+    arg6: usize,
+) -> isize {
+    debug!(
+        "syscall_id: {}, 
+        arg1: {:#x}, arg2: {:#x}, arg3:{:#x}, arg4: {:#x}, arg5:{:#x}, arg6: {:#x}",
+        syscall_id, arg1, arg2, arg3, arg4, arg5, arg6
+    );
+    crate::trap::handle_syscall(syscall_id, [arg1, arg2, arg3, arg4, arg5, arg6])
+}

--- a/modules/ruxhal/src/platform/x86_pc/mod.rs
+++ b/modules/ruxhal/src/platform/x86_pc/mod.rs
@@ -65,6 +65,8 @@ unsafe extern "C" fn rust_entry(magic: usize, mbi: usize) {
         crate::cpu::init_primary(current_cpu_id());
         self::uart16550::init();
         self::dtables::init_primary();
+        #[cfg(feature = "musl")]
+        crate::arch::init_syscall_entry();
         self::time::init_early();
         parse_cmdline(mbi);
         rust_main(current_cpu_id(), 0);
@@ -77,6 +79,8 @@ unsafe extern "C" fn rust_entry_secondary(magic: usize) {
     if magic == self::boot::MULTIBOOT_BOOTLOADER_MAGIC {
         crate::cpu::init_secondary(current_cpu_id());
         self::dtables::init_secondary();
+        #[cfg(feature = "musl")]
+        crate::arch::init_syscall_entry();
         rust_main_secondary(current_cpu_id());
     }
 }

--- a/modules/ruxhal/src/time.rs
+++ b/modules/ruxhal/src/time.rs
@@ -52,7 +52,7 @@ pub fn current_time() -> TimeValue {
         let rtc_time = rtc_read_time();
         return Duration::new(rtc_time, (nanos % (NANOS_PER_SEC)) as u32);
     }
-    TimeValue::from_nanos(current_time_nanos())
+    TimeValue::from_nanos(current_time_nanos() + 1_000_000_000)
 }
 
 /// set time value

--- a/platforms/x86_64-qemu-q35.toml
+++ b/platforms/x86_64-qemu-q35.toml
@@ -9,6 +9,7 @@ family = "x86-pc"
 phys-memory-base = "0"
 # Size of the whole physical memory.
 phys-memory-size = "0x800_0000"     # 128M
+# phys-memory-size = "0x8000_0000"     # 2G
 # Base physical address of the kernel image.
 kernel-base-paddr = "0x20_0000"
 # Base virtual address of the kernel image.

--- a/ulib/ruxlibc/include/sys/stat.h
+++ b/ulib/ruxlibc/include/sys/stat.h
@@ -14,21 +14,46 @@
 #include <sys/time.h>
 #include <sys/types.h>
 
+#if defined(__aarch64__)
 struct stat {
-    dev_t st_dev;             /* ID of device containing file*/
-    ino_t st_ino;             /* inode number*/
-    mode_t st_mode;           /* protection*/
-    nlink_t st_nlink;         /* number of hard links*/
-    uid_t st_uid;             /* user ID of owner*/
-    gid_t st_gid;             /* group ID of owner*/
-    dev_t st_rdev;            /* device ID (if special file)*/
-    off_t st_size;            /* total size, in bytes*/
-    blksize_t st_blksize;     /* blocksize for filesystem I/O*/
-    blkcnt_t st_blocks;       /* number of blocks allocated*/
-    struct timespec st_atime; /* time of last access*/
-    struct timespec st_mtime; /* time of last modification*/
-    struct timespec st_ctime; /* time of last status change*/
+	dev_t st_dev;
+	ino_t st_ino;
+	mode_t st_mode;
+	nlink_t st_nlink;
+	uid_t st_uid;
+	gid_t st_gid;
+	dev_t st_rdev;
+	unsigned long __pad;
+	off_t st_size;
+	blksize_t st_blksize;
+	int __pad2;
+	blkcnt_t st_blocks;
+	struct timespec st_atime;
+	struct timespec st_mtime;
+	struct timespec st_ctime;
+	unsigned __unused[2];
 };
+#else
+struct stat {
+	dev_t st_dev;
+	ino_t st_ino;
+	nlink_t st_nlink;
+
+	mode_t st_mode;
+	uid_t st_uid;
+	gid_t st_gid;
+	unsigned int    __pad0;
+	dev_t st_rdev;
+	off_t st_size;
+	blksize_t st_blksize;
+	blkcnt_t st_blocks;
+
+	struct timespec st_atime;
+	struct timespec st_mtime;
+	struct timespec st_ctime;
+	long __unused[3];
+};
+#endif
 
 #if defined(__aarch64__)
 struct kstat {

--- a/ulib/ruxlibc/include/sys/types.h
+++ b/ulib/ruxlibc/include/sys/types.h
@@ -20,7 +20,13 @@ typedef unsigned u_int, uint;
 typedef unsigned long u_long, ulong;
 
 typedef unsigned mode_t;
+
+#if defined(__aarch64__)
 typedef uint32_t nlink_t;
+#else
+typedef uint64_t nlink_t;
+#endif
+
 typedef int64_t off_t;
 typedef uint64_t ino_t;
 typedef uint64_t dev_t;

--- a/ulib/ruxlibc/src/fs.rs
+++ b/ulib/ruxlibc/src/fs.rs
@@ -42,7 +42,7 @@ pub unsafe extern "C" fn lseek(fd: c_int, offset: ctypes::off_t, whence: c_int) 
 /// Return 0 if success.
 #[no_mangle]
 pub unsafe extern "C" fn stat(path: *const c_char, buf: *mut ctypes::stat) -> c_int {
-    e(sys_stat(path, buf))
+    e(sys_stat(path, buf as _))
 }
 
 /// Get file metadata by `fd` and write into `buf`.

--- a/ulib/ruxmusl/Cargo.toml
+++ b/ulib/ruxmusl/Cargo.toml
@@ -50,6 +50,7 @@ irq = ["ruxos_posix_api/irq", "ruxfeat/irq"]
 sched_rr = ["irq", "ruxfeat/sched_rr"]
 
 [dependencies]
+cfg-if = "1.0"
 ruxfeat = { path = "../../api/ruxfeat" }
 ruxos_posix_api = { path = "../../api/ruxos_posix_api" }
 num_enum = { version = "0.5.11", default-features = false }

--- a/ulib/ruxmusl/src/aarch64/mod.rs
+++ b/ulib/ruxmusl/src/aarch64/mod.rs
@@ -1,6 +1,6 @@
 pub mod syscall_id;
 
-use core::ffi::{c_int, c_uint};
+use core::ffi::c_int;
 use ruxos_posix_api::ctypes;
 use syscall_id::SyscallId;
 
@@ -87,9 +87,9 @@ pub fn syscall(syscall_id: SyscallId, args: [usize; 6]) -> isize {
             ) as _,
             #[cfg(feature = "fs")]
             SyscallId::GETDENTS64 => ruxos_posix_api::sys_getdents64(
-                args[0] as c_uint,
+                args[0] as c_int,
                 args[1] as *mut ctypes::dirent,
-                args[2] as c_uint,
+                args[2] as ctypes::size_t,
             ) as _,
             #[cfg(feature = "fs")]
             SyscallId::LSEEK => ruxos_posix_api::sys_lseek(
@@ -185,7 +185,7 @@ pub fn syscall(syscall_id: SyscallId, args: [usize; 6]) -> isize {
             ) as _,
             SyscallId::CLOCK_SETTIME => ruxos_posix_api::sys_clock_settime(
                 args[0] as ctypes::clockid_t,
-                args[1] as *mut ctypes::timespec,
+                args[1] as *const ctypes::timespec,
             ) as _,
             SyscallId::CLOCK_GETTIME => ruxos_posix_api::sys_clock_gettime(
                 args[0] as ctypes::clockid_t,
@@ -332,7 +332,7 @@ pub fn syscall(syscall_id: SyscallId, args: [usize; 6]) -> isize {
                 args[5] as ctypes::off_t,
             ) as _,
             #[cfg(feature = "alloc")]
-            SyscallId::MADVICE => ruxos_posix_api::sys_madvice(
+            SyscallId::MADVISE => ruxos_posix_api::sys_madvise(
                 args[0] as *mut core::ffi::c_void,
                 args[1] as ctypes::size_t,
                 args[2] as c_int,

--- a/ulib/ruxmusl/src/aarch64/syscall_id.rs
+++ b/ulib/ruxmusl/src/aarch64/syscall_id.rs
@@ -118,7 +118,7 @@ pub enum SyscallId {
     #[cfg(feature = "alloc")]
     MMAP = 222,
     #[cfg(feature = "alloc")]
-    MADVICE = 233,
+    MADVISE = 233,
     #[cfg(feature = "alloc")]
     MPROTECT = 226,
     PRLIMIT64 = 261,

--- a/ulib/ruxmusl/src/dummy/mod.rs
+++ b/ulib/ruxmusl/src/dummy/mod.rs
@@ -1,0 +1,12 @@
+pub mod syscall_id;
+
+use core::ffi::c_int;
+use syscall_id::SyscallId;
+
+pub fn syscall(syscall_id: SyscallId, _args: [usize; 6]) -> isize {
+    debug!("x86 syscall <= syscall_name: {:?}", syscall_id);
+
+    match syscall_id {
+        SyscallId::INVALID => ruxos_posix_api::sys_invalid(syscall_id as usize as c_int) as _,
+    }
+}

--- a/ulib/ruxmusl/src/dummy/syscall_id.rs
+++ b/ulib/ruxmusl/src/dummy/syscall_id.rs
@@ -1,0 +1,10 @@
+use num_enum::TryFromPrimitive;
+
+// TODO: syscall id are architecture-dependent
+#[allow(clippy::upper_case_acronyms)]
+#[allow(non_camel_case_types)]
+#[repr(usize)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, TryFromPrimitive)]
+pub enum SyscallId {
+    INVALID = 999,
+}

--- a/ulib/ruxmusl/src/lib.rs
+++ b/ulib/ruxmusl/src/lib.rs
@@ -12,5 +12,17 @@ extern crate axlog;
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
-mod syscall;
 mod trap;
+
+cfg_if::cfg_if! {
+    if #[cfg(target_arch = "aarch64")]{
+        mod aarch64;
+        use aarch64::{syscall, syscall_id};
+    } else if #[cfg(target_arch = "x86_64")]{
+        mod x86_64;
+        use x86_64::{syscall, syscall_id};
+    } else {
+        mod dummy;
+        use dummy::{syscall, syscall_id};
+    }
+}

--- a/ulib/ruxmusl/src/trap.rs
+++ b/ulib/ruxmusl/src/trap.rs
@@ -2,7 +2,7 @@
 //!
 //! Used to support musl syscall
 
-use crate::syscall::syscall_id::SyscallId;
+use crate::syscall_id::SyscallId;
 
 /// Traphandler used by musl libc, overwrite handler in ruxruntime
 struct TrapHandlerImpl;
@@ -21,6 +21,6 @@ impl ruxhal::trap::TrapHandler for TrapHandlerImpl {
     #[cfg(feature = "musl")]
     fn handle_syscall(syscall_id: usize, args: [usize; 6]) -> isize {
         let id = SyscallId::try_from(syscall_id).unwrap_or(SyscallId::INVALID);
-        crate::syscall::syscall(id, args)
+        crate::syscall(id, args)
     }
 }

--- a/ulib/ruxmusl/src/x86_64/mod.rs
+++ b/ulib/ruxmusl/src/x86_64/mod.rs
@@ -1,0 +1,496 @@
+pub mod syscall_id;
+
+use core::ffi::{c_int, c_ulong, c_void};
+use ruxos_posix_api::ctypes;
+use syscall_id::SyscallId;
+
+pub fn syscall(syscall_id: SyscallId, args: [usize; 6]) -> isize {
+    debug!("x86 syscall <= syscall_name: {:?}", syscall_id);
+
+    unsafe {
+        match syscall_id {
+            SyscallId::INVALID => ruxos_posix_api::sys_invalid(syscall_id as usize as c_int) as _,
+
+            SyscallId::READ => {
+                ruxos_posix_api::sys_read(args[0] as c_int, args[1] as *mut c_void, args[2]) as _
+            }
+
+            SyscallId::WRITE => {
+                ruxos_posix_api::sys_write(args[0] as c_int, args[1] as *const c_void, args[2]) as _
+            }
+
+            #[cfg(feature = "fs")]
+            SyscallId::OPEN => ruxos_posix_api::sys_open(
+                args[0] as *const core::ffi::c_char,
+                args[1] as c_int,
+                args[2] as ctypes::mode_t,
+            ) as _,
+
+            #[cfg(feature = "fd")]
+            SyscallId::CLOSE => ruxos_posix_api::sys_close(args[0] as c_int) as _,
+
+            #[cfg(feature = "fs")]
+            SyscallId::STAT => ruxos_posix_api::sys_stat(
+                args[0] as *const core::ffi::c_char,
+                args[1] as *mut c_void,
+            ) as _,
+
+            #[cfg(feature = "fs")]
+            SyscallId::FSTAT => {
+                ruxos_posix_api::sys_fstat(args[0] as c_int, args[1] as *mut c_void) as _
+            }
+
+            // TODO: lstat is identical to stat(), except that if pathname is a symbolic link,
+            // then it returns information about the link itself, not the file that the link refers to.
+            #[cfg(feature = "fs")]
+            SyscallId::LSTAT => ruxos_posix_api::sys_stat(
+                args[0] as *const core::ffi::c_char,
+                args[1] as *mut c_void,
+            ) as _,
+
+            #[cfg(feature = "poll")]
+            SyscallId::POLL => ruxos_posix_api::sys_poll(
+                args[0] as *mut ctypes::pollfd,
+                args[1] as ctypes::nfds_t,
+                args[2] as c_int,
+            ) as _,
+
+            #[cfg(feature = "fs")]
+            SyscallId::LSEEK => ruxos_posix_api::sys_lseek(
+                args[0] as c_int,
+                args[1] as ctypes::off_t,
+                args[2] as c_int,
+            ) as _,
+
+            #[cfg(feature = "alloc")]
+            SyscallId::MMAP => ruxos_posix_api::sys_mmap(
+                args[0] as *mut c_void,
+                args[1] as ctypes::size_t,
+                args[2] as c_int,
+                args[3] as c_int,
+                args[4] as c_int,
+                args[5] as ctypes::off_t,
+            ) as _,
+
+            #[cfg(feature = "alloc")]
+            SyscallId::MPROTECT => ruxos_posix_api::sys_mprotect(
+                args[0] as *mut c_void,
+                args[1] as ctypes::size_t,
+                args[2] as c_int,
+            ) as _,
+
+            #[cfg(feature = "alloc")]
+            SyscallId::MUNMAP => {
+                ruxos_posix_api::sys_munmap(args[0] as *mut c_void, args[1] as ctypes::size_t) as _
+            }
+
+            #[cfg(feature = "signal")]
+            SyscallId::RT_SIGACTION => ruxos_posix_api::sys_rt_sigaction(
+                args[0] as c_int,
+                args[1] as *const ctypes::sigaction,
+                args[2] as *mut ctypes::sigaction,
+                args[3] as ctypes::size_t,
+            ) as _,
+
+            #[cfg(feature = "signal")]
+            SyscallId::RT_SIGPROCMASK => ruxos_posix_api::sys_rt_sigprocmask(
+                args[0] as c_int,
+                args[1] as *const usize,
+                args[2] as *mut usize,
+                args[3],
+            ) as _,
+
+            #[cfg(feature = "fd")]
+            SyscallId::IOCTL => ruxos_posix_api::sys_ioctl(args[0] as c_int, args[1], args[2]) as _,
+
+            #[cfg(feature = "fd")]
+            SyscallId::READV => ruxos_posix_api::sys_readv(
+                args[0] as c_int,
+                args[1] as *const ctypes::iovec,
+                args[2] as c_int,
+            ) as _,
+
+            #[cfg(feature = "fd")]
+            SyscallId::WRITEV => ruxos_posix_api::sys_writev(
+                args[0] as c_int,
+                args[1] as *const ctypes::iovec,
+                args[2] as c_int,
+            ) as _,
+
+            #[cfg(feature = "pipe")]
+            SyscallId::PIPE => {
+                ruxos_posix_api::sys_pipe(core::slice::from_raw_parts_mut(args[0] as *mut c_int, 2))
+                    as _
+            }
+
+            #[cfg(feature = "select")]
+            SyscallId::SELECT => ruxos_posix_api::sys_select(
+                args[0] as c_int,
+                args[1] as *mut ctypes::fd_set,
+                args[2] as *mut ctypes::fd_set,
+                args[3] as *mut ctypes::fd_set,
+                args[4] as *mut ctypes::timeval,
+            ) as _,
+
+            SyscallId::SCHED_YIELD => ruxos_posix_api::sys_sched_yield() as _,
+
+            #[cfg(feature = "alloc")]
+            SyscallId::MREMAP => ruxos_posix_api::sys_mremap(
+                args[0] as *mut core::ffi::c_void,
+                args[1] as ctypes::size_t,
+                args[2] as ctypes::size_t,
+                args[3] as c_int,
+                args[4] as *mut core::ffi::c_void,
+            ) as _,
+
+            #[cfg(feature = "alloc")]
+            SyscallId::MADVISE => {
+                ruxos_posix_api::sys_madvise(args[0] as *mut c_void, args[1], args[2] as c_int) as _
+            }
+
+            #[cfg(feature = "fd")]
+            SyscallId::DUP => ruxos_posix_api::sys_dup(args[0] as c_int) as _,
+
+            #[cfg(feature = "fd")]
+            SyscallId::DUP2 => ruxos_posix_api::sys_dup2(args[0] as c_int, args[1] as c_int) as _,
+
+            SyscallId::NANO_SLEEP => ruxos_posix_api::sys_nanosleep(
+                args[0] as *const ctypes::timespec,
+                args[1] as *mut ctypes::timespec,
+            ) as _,
+
+            #[cfg(feature = "multitask")]
+            SyscallId::GETPID => ruxos_posix_api::sys_getpid() as _,
+
+            #[cfg(feature = "net")]
+            SyscallId::SOCKET => {
+                ruxos_posix_api::sys_socket(args[0] as c_int, args[1] as c_int, args[2] as c_int)
+                    as _
+            }
+
+            #[cfg(feature = "net")]
+            SyscallId::CONNECT => ruxos_posix_api::sys_connect(
+                args[0] as c_int,
+                args[1] as *const ctypes::sockaddr,
+                args[2] as ctypes::socklen_t,
+            ) as _,
+
+            #[cfg(feature = "net")]
+            SyscallId::ACCEPT => ruxos_posix_api::sys_accept(
+                args[0] as c_int,
+                args[1] as *mut ctypes::sockaddr,
+                args[2] as *mut ctypes::socklen_t,
+            ) as _,
+
+            #[cfg(feature = "net")]
+            SyscallId::SENDTO => ruxos_posix_api::sys_sendto(
+                args[0] as c_int,
+                args[1] as *const core::ffi::c_void,
+                args[2] as ctypes::size_t,
+                args[3] as c_int,
+                args[4] as *const ctypes::sockaddr,
+                args[5] as ctypes::socklen_t,
+            ) as _,
+
+            #[cfg(feature = "net")]
+            SyscallId::RECVFROM => ruxos_posix_api::sys_recvfrom(
+                args[0] as c_int,
+                args[1] as *mut core::ffi::c_void,
+                args[2] as ctypes::size_t,
+                args[3] as c_int,
+                args[4] as *mut ctypes::sockaddr,
+                args[5] as *mut ctypes::socklen_t,
+            ) as _,
+
+            #[cfg(feature = "net")]
+            SyscallId::SENDMSG => ruxos_posix_api::sys_sendmsg(
+                args[0] as c_int,
+                args[1] as *const ctypes::msghdr,
+                args[2] as c_int,
+            ) as _,
+
+            #[cfg(feature = "net")]
+            SyscallId::SHUTDOWN => {
+                ruxos_posix_api::sys_shutdown(args[0] as c_int, args[1] as c_int) as _
+            }
+
+            #[cfg(feature = "net")]
+            SyscallId::BIND => ruxos_posix_api::sys_bind(
+                args[0] as c_int,
+                args[1] as *const ctypes::sockaddr,
+                args[2] as ctypes::socklen_t,
+            ) as _,
+
+            #[cfg(feature = "net")]
+            SyscallId::LISTEN => {
+                ruxos_posix_api::sys_listen(args[0] as c_int, args[1] as c_int) as _
+            }
+
+            #[cfg(feature = "net")]
+            SyscallId::GETSOCKNAME => ruxos_posix_api::sys_getsockname(
+                args[0] as c_int,
+                args[1] as *mut ctypes::sockaddr,
+                args[2] as *mut ctypes::socklen_t,
+            ) as _,
+
+            #[cfg(feature = "net")]
+            SyscallId::GETPEERNAME => ruxos_posix_api::sys_getpeername(
+                args[0] as c_int,
+                args[1] as *mut ctypes::sockaddr,
+                args[2] as *mut ctypes::socklen_t,
+            ) as _,
+
+            #[cfg(feature = "net")]
+            SyscallId::SETSOCKOPT => ruxos_posix_api::sys_setsockopt(
+                args[0] as c_int,
+                args[1] as c_int,
+                args[2] as c_int,
+                args[3] as *const c_void,
+                args[4] as ctypes::socklen_t,
+            ) as _,
+
+            #[cfg(feature = "multitask")]
+            SyscallId::CLONE => ruxos_posix_api::sys_clone(
+                args[0] as c_int,
+                args[1] as *mut c_void,
+                args[2] as *mut ctypes::pid_t,
+                args[3] as *mut ctypes::pid_t,
+                args[4] as *mut c_void,
+                args[5] as *mut c_void,
+            ) as _,
+
+            #[cfg(not(feature = "multitask"))]
+            SyscallId::EXIT => ruxos_posix_api::sys_exit(args[0] as c_int) as _,
+
+            #[allow(unreachable_code)]
+            #[cfg(feature = "multitask")]
+            SyscallId::EXIT => ruxos_posix_api::sys_pthread_exit(args[0] as *mut c_void) as _,
+
+            SyscallId::UNAME => ruxos_posix_api::sys_uname(args[0] as *mut c_void) as _,
+
+            #[cfg(feature = "fd")]
+            SyscallId::FCNTL => {
+                ruxos_posix_api::sys_fcntl(args[0] as c_int, args[1] as c_int, args[2]) as _
+            }
+
+            #[cfg(feature = "fs")]
+            SyscallId::FSYNC => ruxos_posix_api::sys_fsync(args[0] as c_int) as _,
+
+            #[cfg(feature = "fs")]
+            SyscallId::FDATASYNC => ruxos_posix_api::sys_fdatasync(args[0] as c_int) as _,
+
+            #[cfg(feature = "fs")]
+            SyscallId::GETDENTS => ruxos_posix_api::sys_getdents64(
+                args[0] as core::ffi::c_int,
+                args[1] as *mut ctypes::dirent,
+                args[2] as ctypes::size_t,
+            ) as _,
+
+            #[cfg(feature = "fs")]
+            SyscallId::GETCWD => {
+                ruxos_posix_api::sys_getcwd(args[0] as *mut core::ffi::c_char, args[1]) as _
+            }
+
+            #[cfg(feature = "fs")]
+            SyscallId::RENAME => ruxos_posix_api::sys_rename(
+                args[0] as *const core::ffi::c_char,
+                args[1] as *const core::ffi::c_char,
+            ) as _,
+
+            #[cfg(feature = "fs")]
+            SyscallId::MKDIR => ruxos_posix_api::sys_mkdir(
+                args[0] as *const core::ffi::c_char,
+                args[1] as ctypes::mode_t,
+            ) as _,
+
+            #[cfg(feature = "fs")]
+            SyscallId::RMDIR => {
+                ruxos_posix_api::sys_rmdir(args[0] as *const core::ffi::c_char) as _
+            }
+
+            #[cfg(feature = "fs")]
+            SyscallId::UNLINK => {
+                ruxos_posix_api::sys_unlink(args[0] as *const core::ffi::c_char) as _
+            }
+
+            #[cfg(feature = "fs")]
+            SyscallId::READLINK => ruxos_posix_api::sys_readlinkat(
+                ctypes::AT_FDCWD as c_int,
+                args[0] as *const core::ffi::c_char,
+                args[1] as *mut core::ffi::c_char,
+                args[2],
+            ) as _,
+
+            SyscallId::UMASK => ruxos_posix_api::sys_umask(args[0] as ctypes::mode_t) as _,
+
+            SyscallId::GETTIMEOFDAY => ruxos_posix_api::sys_gettimeofday(
+                args[0] as *mut ctypes::timespec,
+                args[1] as c_int,
+            ) as _,
+
+            SyscallId::GETRLIMIT => {
+                ruxos_posix_api::sys_getrlimit(args[0] as c_int, args[1] as *mut ctypes::rlimit)
+                    as _
+            }
+
+            SyscallId::SYSINFO => {
+                ruxos_posix_api::sys_sysinfo(args[0] as *mut ctypes::sysinfo) as _
+            }
+
+            #[cfg(feature = "signal")]
+            SyscallId::SIGALTSTACK => {
+                ruxos_posix_api::sys_sigaltstack(args[0] as *const c_void, args[1] as *mut c_void)
+                    as _
+            }
+
+            SyscallId::PRCTL => ruxos_posix_api::sys_prctl(
+                args[0] as c_int,
+                args[1] as c_ulong,
+                args[2] as c_ulong,
+                args[3] as c_ulong,
+                args[4] as c_ulong,
+            ) as _,
+
+            SyscallId::ARCH_PRCTL => {
+                ruxos_posix_api::sys_arch_prctl(args[0] as c_int, args[1] as c_ulong) as _
+            }
+
+            #[cfg(feature = "multitask")]
+            SyscallId::FUTEX => ruxos_posix_api::sys_futex(
+                args[0],
+                args[1] as c_int,
+                args[2] as c_int,
+                args[3],
+                args[4] as c_int,
+                args[5] as c_int,
+            ) as _,
+
+            #[cfg(feature = "epoll")]
+            SyscallId::EPOLL_CREATE => ruxos_posix_api::sys_epoll_create(args[0] as c_int) as _,
+
+            #[cfg(feature = "fs")]
+            SyscallId::GETDENTS64 => ruxos_posix_api::sys_getdents64(
+                args[0] as c_int,
+                args[1] as *mut ctypes::dirent,
+                args[2],
+            ) as _,
+
+            #[cfg(feature = "multitask")]
+            SyscallId::SET_TID_ADDRESS => ruxos_posix_api::sys_set_tid_address(args[0]) as _,
+
+            SyscallId::CLOCK_SETTIME => ruxos_posix_api::sys_clock_settime(
+                args[0] as c_int,
+                args[1] as *const ctypes::timespec,
+            ) as _,
+
+            SyscallId::CLOCK_GETTIME => ruxos_posix_api::sys_clock_gettime(
+                args[0] as c_int,
+                args[1] as *mut ctypes::timespec,
+            ) as _,
+
+            #[cfg(feature = "epoll")]
+            SyscallId::EPOLL_WAIT => ruxos_posix_api::sys_epoll_wait(
+                args[0] as c_int,
+                args[1] as *mut ctypes::epoll_event,
+                args[2] as c_int,
+                args[3] as c_int,
+            ) as _,
+
+            #[cfg(feature = "epoll")]
+            SyscallId::EPOLL_CTL => ruxos_posix_api::sys_epoll_ctl(
+                args[0] as c_int,
+                args[1] as c_int,
+                args[2] as c_int,
+                args[3] as *mut ctypes::epoll_event,
+            ) as _,
+
+            #[cfg(feature = "fs")]
+            SyscallId::OPENAT => ruxos_posix_api::sys_openat(
+                args[0],
+                args[1] as *const core::ffi::c_char,
+                args[2] as c_int,
+                args[3] as ctypes::mode_t,
+            ) as _,
+
+            #[cfg(feature = "fs")]
+            SyscallId::MKDIRAT => ruxos_posix_api::sys_mkdirat(
+                args[0] as c_int,
+                args[1] as *const core::ffi::c_char,
+                args[2] as ctypes::mode_t,
+            ) as _,
+
+            #[cfg(feature = "fs")]
+            SyscallId::NEWFSTATAT => ruxos_posix_api::sys_newfstatat(
+                args[0] as c_int,
+                args[1] as *const core::ffi::c_char,
+                args[2] as *mut ctypes::kstat,
+                args[3] as c_int,
+            ) as _,
+
+            #[cfg(feature = "fs")]
+            SyscallId::UNLINKAT => ruxos_posix_api::sys_unlinkat(
+                args[0] as c_int,
+                args[1] as *const core::ffi::c_char,
+                args[2] as c_int,
+            ) as _,
+
+            #[cfg(feature = "fs")]
+            SyscallId::RENAMEAT => ruxos_posix_api::sys_renameat(
+                args[0] as c_int,
+                args[1] as *const core::ffi::c_char,
+                args[2] as c_int,
+                args[3] as *const core::ffi::c_char,
+            ) as _,
+
+            #[cfg(feature = "select")]
+            SyscallId::PSELECT6 => ruxos_posix_api::sys_pselect6(
+                args[0] as c_int,
+                args[1] as *mut ctypes::fd_set,
+                args[2] as *mut ctypes::fd_set,
+                args[3] as *mut ctypes::fd_set,
+                args[4] as *mut ctypes::timeval,
+                args[5] as *const c_void,
+            ) as _,
+
+            #[cfg(feature = "poll")]
+            SyscallId::PPOLL => ruxos_posix_api::sys_ppoll(
+                args[0] as *mut ctypes::pollfd,
+                args[1] as ctypes::nfds_t,
+                args[2] as *const ctypes::timespec,
+                args[3] as *const ctypes::sigset_t,
+                args[4] as ctypes::size_t,
+            ) as _,
+
+            #[cfg(feature = "epoll")]
+            SyscallId::EPOLL_PWAIT => ruxos_posix_api::sys_epoll_pwait(
+                args[0] as c_int,
+                args[1] as *mut ctypes::epoll_event,
+                args[2] as c_int,
+                args[3] as c_int,
+                args[4] as *const ctypes::sigset_t,
+                args[5] as *const ctypes::size_t,
+            ) as _,
+
+            #[cfg(feature = "epoll")]
+            SyscallId::EPOLL_CREATE1 => ruxos_posix_api::sys_epoll_create(args[0] as c_int) as _,
+
+            #[cfg(feature = "fd")]
+            SyscallId::DUP3 => {
+                ruxos_posix_api::sys_dup3(args[0] as c_int, args[1] as c_int, args[2] as c_int) as _
+            }
+
+            #[cfg(feature = "pipe")]
+            SyscallId::PIPE2 => ruxos_posix_api::sys_pipe2(
+                core::slice::from_raw_parts_mut(args[0] as *mut c_int, 2),
+                args[1] as c_int,
+            ) as _,
+
+            SyscallId::PRLIMIT64 => ruxos_posix_api::sys_prlimit64(
+                args[0] as ctypes::pid_t,
+                args[1] as c_int,
+                args[2] as *const ctypes::rlimit,
+                args[3] as *mut ctypes::rlimit,
+            ) as _,
+        }
+    }
+}

--- a/ulib/ruxmusl/src/x86_64/syscall_id.rs
+++ b/ulib/ruxmusl/src/x86_64/syscall_id.rs
@@ -1,0 +1,229 @@
+use num_enum::TryFromPrimitive;
+
+// TODO: syscall id are architecture-dependent
+#[allow(clippy::upper_case_acronyms)]
+#[allow(non_camel_case_types)]
+#[repr(usize)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, TryFromPrimitive)]
+pub enum SyscallId {
+    INVALID = 999,
+
+    READ = 0,
+    WRITE = 1,
+
+    #[cfg(feature = "fs")]
+    OPEN = 2,
+
+    #[cfg(feature = "fd")]
+    CLOSE = 3,
+
+    #[cfg(feature = "fs")]
+    STAT = 4,
+
+    #[cfg(feature = "fs")]
+    FSTAT = 5,
+
+    #[cfg(feature = "fs")]
+    LSTAT = 6,
+
+    #[cfg(feature = "poll")]
+    POLL = 7,
+
+    #[cfg(feature = "fs")]
+    LSEEK = 8,
+
+    #[cfg(feature = "alloc")]
+    MMAP = 9,
+
+    #[cfg(feature = "alloc")]
+    MPROTECT = 10,
+
+    #[cfg(feature = "alloc")]
+    MUNMAP = 11,
+
+    #[cfg(feature = "signal")]
+    RT_SIGACTION = 13,
+
+    #[cfg(feature = "signal")]
+    RT_SIGPROCMASK = 14,
+
+    #[cfg(feature = "fd")]
+    IOCTL = 16,
+
+    #[cfg(feature = "fd")]
+    READV = 19,
+
+    #[cfg(feature = "fd")]
+    WRITEV = 20,
+
+    #[cfg(feature = "pipe")]
+    PIPE = 22,
+
+    #[cfg(feature = "select")]
+    SELECT = 23,
+
+    SCHED_YIELD = 24,
+
+    #[cfg(feature = "alloc")]
+    MREMAP = 25,
+
+    #[cfg(feature = "alloc")]
+    MADVISE = 28,
+
+    #[cfg(feature = "fd")]
+    DUP = 32,
+
+    #[cfg(feature = "fd")]
+    DUP2 = 33,
+
+    NANO_SLEEP = 35,
+
+    #[cfg(feature = "multitask")]
+    GETPID = 39,
+
+    #[cfg(feature = "net")]
+    SOCKET = 41,
+
+    #[cfg(feature = "net")]
+    CONNECT = 42,
+
+    #[cfg(feature = "net")]
+    ACCEPT = 43,
+
+    #[cfg(feature = "net")]
+    SENDTO = 44,
+
+    #[cfg(feature = "net")]
+    RECVFROM = 45,
+
+    #[cfg(feature = "net")]
+    SENDMSG = 46,
+
+    #[cfg(feature = "net")]
+    SHUTDOWN = 48,
+
+    #[cfg(feature = "net")]
+    BIND = 49,
+
+    #[cfg(feature = "net")]
+    LISTEN = 50,
+
+    #[cfg(feature = "net")]
+    GETSOCKNAME = 51,
+
+    #[cfg(feature = "net")]
+    GETPEERNAME = 52,
+
+    #[cfg(feature = "net")]
+    SETSOCKOPT = 54,
+
+    // TODO: check clone
+    #[cfg(feature = "multitask")]
+    CLONE = 56,
+
+    EXIT = 60,
+
+    UNAME = 63,
+
+    #[cfg(feature = "fd")]
+    FCNTL = 72,
+
+    #[cfg(feature = "fs")]
+    FSYNC = 74,
+
+    #[cfg(feature = "fs")]
+    FDATASYNC = 75,
+
+    #[cfg(feature = "fs")]
+    GETDENTS = 78,
+
+    #[cfg(feature = "fs")]
+    GETCWD = 79,
+
+    #[cfg(feature = "fs")]
+    RENAME = 82,
+
+    #[cfg(feature = "fs")]
+    MKDIR = 83,
+
+    #[cfg(feature = "fs")]
+    RMDIR = 84,
+
+    #[cfg(feature = "fs")]
+    UNLINK = 87,
+
+    #[cfg(feature = "fs")]
+    READLINK = 89,
+
+    UMASK = 95,
+
+    GETTIMEOFDAY = 96,
+
+    GETRLIMIT = 97,
+
+    SYSINFO = 99,
+
+    #[cfg(feature = "signal")]
+    SIGALTSTACK = 131,
+
+    PRCTL = 157,
+
+    ARCH_PRCTL = 158,
+
+    #[cfg(feature = "multitask")]
+    FUTEX = 202,
+
+    #[cfg(feature = "epoll")]
+    EPOLL_CREATE = 213,
+
+    #[cfg(feature = "fs")]
+    GETDENTS64 = 217,
+
+    #[cfg(feature = "multitask")]
+    SET_TID_ADDRESS = 218,
+
+    CLOCK_SETTIME = 227,
+
+    CLOCK_GETTIME = 228,
+
+    #[cfg(feature = "epoll")]
+    EPOLL_WAIT = 232,
+
+    #[cfg(feature = "epoll")]
+    EPOLL_CTL = 233,
+
+    #[cfg(feature = "fs")]
+    OPENAT = 257,
+
+    #[cfg(feature = "fs")]
+    MKDIRAT = 258,
+
+    #[cfg(feature = "fs")]
+    NEWFSTATAT = 262,
+
+    #[cfg(feature = "fs")]
+    UNLINKAT = 263,
+
+    #[cfg(feature = "fs")]
+    RENAMEAT = 264,
+
+    #[cfg(feature = "select")]
+    PSELECT6 = 270,
+
+    #[cfg(feature = "poll")]
+    PPOLL = 271,
+
+    #[cfg(feature = "epoll")]
+    EPOLL_PWAIT = 281,
+
+    #[cfg(feature = "epoll")]
+    EPOLL_CREATE1 = 291,
+
+    #[cfg(feature = "fd")]
+    DUP3 = 292,
+
+    #[cfg(feature = "pipe")]
+    PIPE2 = 293,
+
+    PRLIMIT64 = 302,
+}


### PR DESCRIPTION
- [ ] Add musl libc support on x86_64.
- [ ] Fix bugs for `stat-related` functions: the size of  `nlink_t` should by architecture-dependent.
- [ ] Add a simple check for `sys_futex`'s `to` paramter.