### PR TITLE
fix problem in `random-hw`, `9p` and `pl011`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1970,7 +1970,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "virtio-drivers"
 version = "0.4.0"
-source = "git+https://github.com/syswonder/virtio-drivers.git?rev=256ec4c#256ec4ca669a40719090aeaec858f707e8259183"
+source = "git+https://github.com/syswonder/virtio-drivers.git?rev=62dbe5a#62dbe5a09aff0cac00037c8fe6528d94665286b8"
 dependencies = [
  "bitflags 1.3.2",
  "log",

--- a/api/ruxos_posix_api/src/imp/getrandom.rs
+++ b/api/ruxos_posix_api/src/imp/getrandom.rs
@@ -22,6 +22,9 @@ use crate::ctypes::{size_t, ssize_t};
 
 use axerrno::LinuxError;
 
+#[cfg(all(target_arch = "x86_64", feature = "random-hw"))]
+use core::arch::x86_64::__cpuid;
+
 static SEED: AtomicU64 = AtomicU64::new(0xae_f3);
 
 /// Returns a 32-bit unsigned pseudo random interger using LCG.
@@ -54,15 +57,7 @@ fn srand_lcg(seed: u64) {
 fn has_rdrand() -> bool {
     #[cfg(target_arch = "x86_64")]
     {
-        let mut ecx: u32;
-        unsafe {
-            core::arch::asm!(
-                "mov eax, 1",
-                "cpuid",
-                out("ecx") ecx
-            )
-        }
-        ecx & (1 << 30) != 0
+        unsafe { __cpuid(1).ecx & (1 << 30) != 0 }
     }
     #[cfg(target_arch = "aarch64")]
     {

--- a/crates/driver_pci/Cargo.toml
+++ b/crates/driver_pci/Cargo.toml
@@ -10,4 +10,4 @@ repository = "https://github.com/rcore-os/arceos/tree/main/crates/driver_pci"
 documentation = "https://rcore-os.github.io/arceos/driver_pci/index.html"
 
 [dependencies]
-virtio-drivers = { git = "https://github.com/syswonder/virtio-drivers.git", rev = "256ec4c"}
+virtio-drivers = { git = "https://github.com/syswonder/virtio-drivers.git", rev = "62dbe5a"}

--- a/crates/driver_virtio/Cargo.toml
+++ b/crates/driver_virtio/Cargo.toml
@@ -23,4 +23,4 @@ driver_block = { path = "../driver_block", optional = true }
 driver_net = { path = "../driver_net", optional = true }
 driver_display = { path = "../driver_display", optional = true}
 driver_9p = { path = "../driver_9p", optional = true}
-virtio-drivers = { git = "https://github.com/syswonder/virtio-drivers.git", rev = "256ec4c" }
+virtio-drivers = { git = "https://github.com/syswonder/virtio-drivers.git", rev = "62dbe5a" }

--- a/modules/rux9p/src/drv.rs
+++ b/modules/rux9p/src/drv.rs
@@ -400,7 +400,7 @@ impl Drv9pOps {
 
     /// write perform I/O on the file represented by fid.
     /// Note that in v9fs, a read(2) or write(2) system call for a chunk of the file that won't fit in a single request is broken up into multiple requests.
-    pub fn twrite(&mut self, fid: u32, offset: u64, data: &[u8]) -> Result<u8, u8> {
+    pub fn twrite(&mut self, fid: u32, offset: u64, data: &[u8]) -> Result<usize, u8> {
         const MAX_READ_LEN: u32 = _9P_MAX_PSIZE - 32;
         let mut writing_len = data.len() as u32;
         if writing_len > MAX_READ_LEN {
@@ -416,7 +416,7 @@ impl Drv9pOps {
         }
         request.finish();
         match self.request(&request.buffer, &mut response_buffer) {
-            Ok(_) => Ok(lbytes2u64(&response_buffer[7..11]) as u8), // index from 7 to 11 corresponing to total count of writed byte
+            Ok(_) => Ok(lbytes2u64(&response_buffer[7..11]) as usize), // index from 7 to 11 corresponing to total count of writed byte
             Err(ecode) => Err(ecode),
         }
     }
@@ -903,6 +903,10 @@ impl FileAttr {
         }
     }
 
+    pub fn get_perm(&self) -> u32 {
+        self.mode
+    }
+
     pub fn set_size(&mut self, size: u64) {
         self.vaild |= _9P_SETATTR_SIZE;
         self.size = size;
@@ -1016,6 +1020,10 @@ impl UStatFs {
 
     pub fn get_name(&self) -> String {
         self.name.clone()
+    }
+
+    pub fn get_perm(&self) -> u32 {
+        self.mode
     }
 
     pub fn get_ftype(&self) -> u8 {

--- a/modules/ruxhal/src/platform/aarch64_common/pl011.rs
+++ b/modules/ruxhal/src/platform/aarch64_common/pl011.rs
@@ -8,21 +8,67 @@
  */
 
 //! PL011 UART.
-
 use arm_pl011::pl011::Pl011Uart;
+use cfg_if::cfg_if;
 use memory_addr::PhysAddr;
 use spinlock::SpinNoIrq;
 
 use crate::mem::phys_to_virt;
 
 const UART_BASE: PhysAddr = PhysAddr::from(ruxconfig::UART_PADDR);
+#[cfg(feature = "irq")]
+const BUFFER_SIZE: usize = 128;
 
-static UART: SpinNoIrq<Pl011Uart> =
-    SpinNoIrq::new(Pl011Uart::new(phys_to_virt(UART_BASE).as_mut_ptr()));
+#[cfg(feature = "irq")]
+struct RxRingBuffer {
+    buffer: [u8; BUFFER_SIZE],
+    head: usize,
+    tail: usize,
+}
+
+#[cfg(feature = "irq")]
+impl RxRingBuffer {
+    const fn new() -> Self {
+        RxRingBuffer {
+            buffer: [0_u8; BUFFER_SIZE],
+            head: 0_usize,
+            tail: 0_usize,
+        }
+    }
+
+    fn push(&mut self, n: u8) {
+        if self.tail != self.head {
+            self.buffer[self.tail] = n;
+            self.tail = (self.tail + 1) % BUFFER_SIZE;
+        }
+    }
+
+    fn pop(&mut self) -> Option<u8> {
+        if self.head == self.tail {
+            None
+        } else {
+            let ret = self.buffer[self.head];
+            self.head += (self.head + 1) % BUFFER_SIZE;
+            Some(ret)
+        }
+    }
+}
+
+struct UartDrv {
+    inner: SpinNoIrq<Pl011Uart>,
+    #[cfg(feature = "irq")]
+    buffer: SpinNoIrq<RxRingBuffer>,
+}
+
+static UART: UartDrv = UartDrv {
+    inner: SpinNoIrq::new(Pl011Uart::new(phys_to_virt(UART_BASE).as_mut_ptr())),
+    #[cfg(feature = "irq")]
+    buffer: SpinNoIrq::new(RxRingBuffer::new()),
+};
 
 /// Writes a byte to the console.
 pub fn putchar(c: u8) {
-    let mut uart = UART.lock();
+    let mut uart = UART.inner.lock();
     match c {
         b'\n' => {
             uart.putchar(b'\r');
@@ -34,27 +80,37 @@ pub fn putchar(c: u8) {
 
 /// Reads a byte from the console, or returns [`None`] if no input is available.
 pub fn getchar() -> Option<u8> {
-    UART.lock().getchar()
+    cfg_if! {
+        if #[cfg(feature = "irq")] {
+            UART.buffer.lock().pop()
+        }else{
+            UART.inner.lock().getchar()
+        }
+    }
 }
 
 /// Initialize the UART
 pub fn init_early() {
-    UART.lock().init();
+    UART.inner.lock().init();
 }
 
 /// Set UART IRQ Enable
 pub fn init() {
     #[cfg(feature = "irq")]
-    crate::irq::set_enable(crate::platform::irq::UART_IRQ_NUM, true);
+    {
+        crate::irq::register_handler(crate::platform::irq::UART_IRQ_NUM, handle);
+        crate::irq::set_enable(crate::platform::irq::UART_IRQ_NUM, true);
+    }
 }
 
 /// UART IRQ Handler
+#[cfg(feature = "irq")]
 pub fn handle() {
-    let is_receive_interrupt = UART.lock().is_receive_interrupt();
-    UART.lock().ack_interrupts();
+    let is_receive_interrupt = UART.inner.lock().is_receive_interrupt();
     if is_receive_interrupt {
-        while let Some(c) = getchar() {
-            putchar(c);
+        UART.inner.lock().ack_interrupts();
+        while let Some(c) = UART.inner.lock().getchar() {
+            UART.buffer.lock().push(c);
         }
     }
 }


### PR DESCRIPTION
1. fix bug in function `has_rdrand`, which may cause an endless cycle.
2. fix bugs in 9pfs, which may cause some `net-9p` open fault (for some backend), or a wrong return value when writing.
3. fix bug in pl011, which actually has no handler when irq is enable.
4. improve the performance of 9pfs for read_dir().
