### PR TITLE
fix bugs in mmap and warnings for clippy

### DIFF
--- a/api/ruxos_posix_api/src/imp/mmap/trap.rs
+++ b/api/ruxos_posix_api/src/imp/mmap/trap.rs
@@ -44,7 +44,7 @@ impl ruxhal::trap::TrapHandler for TrapHandlerImpl {
             let map_flag = get_mflags_from_usize(vma.prot);
 
             trace!(
-                "Page Fault Happening, vaddr:{:x?}, casue:{:?}, map_flags:{:x?}",
+                "Page Fault Happening, vaddr:0x{:x?}, casue:{:?}, map_flags:0x{:x?}",
                 vaddr,
                 cause,
                 map_flag
@@ -141,9 +141,9 @@ impl ruxhal::trap::TrapHandler for TrapHandlerImpl {
             }
         } else {
             for mapped in vma_map.iter() {
-                warn!("{:x?}", mapped);
+                warn!("0x{:x?}", mapped);
             }
-            warn!("vaddr={:x?},cause={:x?}", vaddr, cause);
+            warn!("vaddr=0x{:x?},cause=0x{:x?}", vaddr, cause);
             false
         }
     }

--- a/api/ruxos_posix_api/src/imp/stdio.rs
+++ b/api/ruxos_posix_api/src/imp/stdio.rs
@@ -10,12 +10,11 @@
 use axerrno::AxResult;
 use axio::{prelude::*, BufReader};
 use axsync::Mutex;
+
 #[cfg(feature = "fd")]
 use {
     alloc::sync::Arc,
-    axerrno::AxError,
-    axerrno::LinuxError,
-    axerrno::LinuxResult,
+    axerrno::{AxError, LinuxError, LinuxResult},
     axio::PollState,
     core::sync::atomic::{AtomicBool, Ordering},
 };

--- a/modules/axnet/src/smoltcp_impl/tcp.rs
+++ b/modules/axnet/src/smoltcp_impl/tcp.rs
@@ -34,10 +34,8 @@ const STATE_CONNECTING: u8 = 2;
 const STATE_CONNECTED: u8 = 3;
 const STATE_LISTENING: u8 = 4;
 
-const MSG_OOB: i32 = 1;
 const MSG_PEEK: i32 = 2;
 const MSG_DONTWAIT: i32 = 4;
-const MSG_CTRUNC: i32 = 8;
 
 /// A TCP socket that provides POSIX-like APIs.
 ///

--- a/modules/ruxhal/src/paging.rs
+++ b/modules/ruxhal/src/paging.rs
@@ -135,7 +135,7 @@ pub fn alloc_page_preload() -> Result<VirtAddr, PagingError> {
 /// address is still on linear mapping region.
 /// use `do_pte_map` to do actually page mapping after call this function.
 pub fn pte_swap_preload(swaped_vaddr: VirtAddr) -> PagingResult<VirtAddr> {
-    trace!("swapping swaped_vaddr: {:x?}", swaped_vaddr,);
+    trace!("swapping swaped_vaddr: 0x{:x?}", swaped_vaddr,);
     let mut kernel_page_table = KERNEL_PAGE_TABLE.lock();
     let (paddr, _) = kernel_page_table.unmap(swaped_vaddr)?;
     flush_tlb(Some(swaped_vaddr));
@@ -170,7 +170,12 @@ pub fn pte_update_page(
     paddr: Option<PhysAddr>,
     flags: Option<MappingFlags>,
 ) -> PagingResult {
-    trace!("updating vaddr: {:x?} {:x?} {:x?}", vaddr, paddr, flags);
+    trace!(
+        "updating vaddr:0x{:x?} paddr:0x{:x?} flags:0x{:x?}",
+        vaddr,
+        paddr,
+        flags
+    );
     KERNEL_PAGE_TABLE.lock().update(vaddr, paddr, flags)?;
     flush_tlb(Some(vaddr));
     Ok(())
@@ -180,7 +185,7 @@ pub fn pte_update_page(
 ///
 /// release the corresponding memory at the same time
 pub fn pte_unmap_page(vaddr: VirtAddr) -> PagingResult {
-    trace!("unmapping vaddr: {:x?}", vaddr);
+    trace!("unmapping vaddr: 0x{:x?}", vaddr);
     let (paddr, _) = KERNEL_PAGE_TABLE.lock().unmap(vaddr)?;
     global_allocator().dealloc_pages(phys_to_virt(paddr).as_usize(), 1);
     flush_tlb(Some(vaddr));

--- a/modules/ruxhal/src/platform/aarch64_common/pl031.rs
+++ b/modules/ruxhal/src/platform/aarch64_common/pl031.rs
@@ -53,11 +53,11 @@ impl Pl031rtc {
     }
 
     pub unsafe fn read(&self, reg: u32) -> u32 {
-        core::ptr::read_volatile((PHYS_RTC + reg as usize) as *const u32)
+        core::ptr::read_volatile((self.address + reg as usize) as *const u32)
     }
 
     pub unsafe fn write(&self, reg: u32, value: u32) {
-        core::ptr::write_volatile((PHYS_RTC + reg as usize) as *mut u32, value);
+        core::ptr::write_volatile((self.address + reg as usize) as *mut u32, value);
     }
 
     pub fn time(&self) -> u64 {

--- a/ulib/ruxlibc/src/io.rs
+++ b/ulib/ruxlibc/src/io.rs
@@ -11,7 +11,9 @@ use core::ffi::{c_int, c_void};
 #[cfg(feature = "fd")]
 use ruxos_posix_api::sys_ioctl;
 
-use ruxos_posix_api::{sys_read, sys_write, sys_writev};
+#[cfg(not(test))]
+use ruxos_posix_api::sys_write;
+use ruxos_posix_api::{sys_read, sys_writev};
 
 use crate::{ctypes, utils::e};
 

--- a/ulib/ruxmusl/src/lib.rs
+++ b/ulib/ruxmusl/src/lib.rs
@@ -20,6 +20,7 @@ cfg_if::cfg_if! {
         use aarch64::{syscall, syscall_id};
     } else if #[cfg(target_arch = "x86_64")]{
         mod x86_64;
+        #[cfg(feature = "musl")]
         use x86_64::{syscall, syscall_id};
     } else {
         mod dummy;

--- a/ulib/ruxmusl/src/trap.rs
+++ b/ulib/ruxmusl/src/trap.rs
@@ -1,7 +1,7 @@
 //! Traphandle implementation
 //!
 //! Used to support musl syscall
-
+#[cfg(feature = "musl")]
 use crate::syscall_id::SyscallId;
 
 /// Traphandler used by musl libc, overwrite handler in ruxruntime

--- a/ulib/ruxmusl/src/x86_64/mod.rs
+++ b/ulib/ruxmusl/src/x86_64/mod.rs
@@ -1,9 +1,11 @@
 pub mod syscall_id;
 
+#[allow(unused_imports)]
 use core::ffi::{c_char, c_int, c_ulong, c_void};
 use ruxos_posix_api::ctypes::{self, gid_t, pid_t, uid_t};
 use syscall_id::SyscallId;
 
+#[allow(dead_code)]
 pub fn syscall(syscall_id: SyscallId, args: [usize; 6]) -> isize {
     debug!("x86 syscall <= syscall_name: {:?}", syscall_id);
 
@@ -288,6 +290,7 @@ pub fn syscall(syscall_id: SyscallId, args: [usize; 6]) -> isize {
                 ruxos_posix_api::sys_execve(args[0] as *const c_char, args[1], args[2]) as _
             }
 
+            #[allow(unreachable_code)]
             #[cfg(not(feature = "multitask"))]
             SyscallId::EXIT => ruxos_posix_api::sys_exit(args[0] as c_int) as _,
 


### PR DESCRIPTION
FIx two problem in mmap and munmap:
1. part of the memory may be released when munmap fails.
2. The semantic error of mmap's MAP_FIXED flag.
and clean warnings in `make clippy` and `make unittest`.