### PR TITLE
modify c++ benchmark

### DIFF
--- a/apps/c/cpp/axbuild.mk
+++ b/apps/c/cpp/axbuild.mk
@@ -13,8 +13,7 @@ std_benchmark_dir := $(APP)/std-benchmark
 std_benchmark_build = $(std_benchmark_dir)/build
 
 bench ?= all
-benches_available := $(wildcard $(std_benchmark_dir)/cxx/*.bench.cpp)
-benches_available := $(patsubst $(std_benchmark_dir)/cxx/%.bench.cpp,%,$(benches_available))
+benches_available := accessors algorithm mutators size_metric string stringstream
 
 $(std_benchmark_dir):
 	@echo "Download std-benchmark source code"
@@ -31,7 +30,7 @@ build_std-benchmark: $(std_benchmark_dir) $(APP)/axbuild.mk
 		ln -s -f $(CROSS_COMPILE_PATH)/lib/gcc/*-linux-musl/*/libgcc.a ./ && \
 		$(AR) x libgcc.a _clrsbsi2.o
 ifeq ($(bench), all)
-	$(error "Running all benches automatically is not supported, please add 'bench=' arg. \
+	$(error "Running all benches automatically is not supported currently, please add 'bench=' arg. \
 		Available benches: $(benches_available)")
 endif
 ifneq ($(filter $(bench),$(benches_available)),)
@@ -49,5 +48,3 @@ clean_c::
 	rm -rf $(std_benchmark_build)/
 
 .PHONY: build_std-benchmark clean_c
-
-

--- a/apps/c/cpp/std_benchmark.patch
+++ b/apps/c/cpp/std_benchmark.patch
@@ -55,16 +55,7 @@
      v.insert(v.begin(), val);
    }
    state.SetComplexityN(N);
-@@ -94,14 +95,15 @@ void BM_assoc_insert_random(benchmark::State& state) {
-   int N = state.range(0);
-   using CVT = typename V::value_type;
-   using VT = typename remove_const<CVT>::type;
--  std::vector<VT> temp(N*1000);
-+  // TODO: It will panic if *100 or *1000
-+  std::vector<VT> temp(N*10);
-   fill_random(temp);
-   V v;
-   auto it = temp.begin();
+@@ -101,7 +101,7 @@ void BM_assoc_insert_random(benchmark::State& state) {
    while (state.KeepRunning()) {
      v.insert(*it++);
      if (it == temp.end()) // FIXME: After temp.end insert will just return.
@@ -73,6 +64,29 @@
    }
    state.SetComplexityN(N);
  }
+--- /cxx/size_metric.bench.cpp
++++ /cxx/size_metric.bench.cpp
+@@ -7,6 +7,8 @@
+ #include<unordered_set>
+ #include<vector>
+ 
++#include "test_configs.h"
++
+ #define GETNAME(T) #T
+ 
+ template<typename T>
+--- /cxx/string.bench.cpp
++++ /cxx/string.bench.cpp
+@@ -77,7 +77,8 @@ static void BM_strcat(benchmark::State& state) {
+     benchmark::DoNotOptimize(s1.append(s2));
+     s1_sz += s2_sz;
+     if (s1_sz >= N) {
+-      //
++      s1_sz = 1;
++      s1 = std::string(N, 0);
+     }
+   }
+   state.SetComplexityN(N);
 --- /include/test_configs.h
 +++ /include/test_configs.h
 @@ -1,6 +1,8 @@
@@ -107,3 +121,22 @@
  if(NOT HAVE_STD_REGEX AND NOT HAVE_GNU_POSIX_REGEX AND NOT HAVE_POSIX_REGEX)
    message(FATAL_ERROR "Failed to determine the source files for the regular expression backend")
  endif()
+--- /include/rng_utils.h
++++ /include/rng_utils.h
+@@ -30,9 +30,9 @@ template<class T> using gen = typename uniform_distribution<T>::type;
+ 
+ class random_device {
+ public:
++  random_device() : e(rd()) {}
+   template<typename T>
+   T get_rand(T min, T max) {
+-    std::mt19937 e(rd()); // seed the generator
+     gen<T> d(min, max); // define the range
+     return d(e);
+   }
+@@ -40,6 +40,7 @@ public:
+ private:
+   // TODO: Fix the seed to a constant.
+   std::random_device rd; // obtain a random number from hardware
++  std::mt19937 e; // seed the generator
+ };


### PR DESCRIPTION
I modified c++ benchmark patch to avoid memory allocation failures, which caused by too many iteration counts.