### PR TITLE
fix problems in mmap and syscall handler

### DIFF
--- a/api/ruxos_posix_api/src/imp/fs.rs
+++ b/api/ruxos_posix_api/src/imp/fs.rs
@@ -23,21 +23,21 @@ use crate::{ctypes, utils::char_ptr_to_str};
 use alloc::vec::Vec;
 
 pub struct File {
-    inner: Mutex<ruxfs::fops::File>,
+    pub(crate) inner: Mutex<ruxfs::fops::File>,
 }
 
 impl File {
-    fn new(inner: ruxfs::fops::File) -> Self {
+    pub(crate) fn new(inner: ruxfs::fops::File) -> Self {
         Self {
             inner: Mutex::new(inner),
         }
     }
 
-    fn add_to_fd_table(self) -> LinuxResult<c_int> {
+    pub(crate) fn add_to_fd_table(self) -> LinuxResult<c_int> {
         super::fd_ops::add_file_like(Arc::new(self))
     }
 
-    fn from_fd(fd: c_int) -> LinuxResult<Arc<Self>> {
+    pub(crate) fn from_fd(fd: c_int) -> LinuxResult<Arc<Self>> {
         let f = super::fd_ops::get_file_like(fd)?;
         f.into_any()
             .downcast::<Self>()

--- a/modules/ruxconfig/defconfig.toml
+++ b/modules/ruxconfig/defconfig.toml
@@ -31,8 +31,8 @@ pci-ranges = []
 timer-frequency = "0"
 
 # Stack size of each task.
-task-stack-size = "0x40000"   # 256 K
-# task-stack-size = "0x80000"   # 512 K
+# task-stack-size = "0x40000"   # 256 K
+task-stack-size = "0x80000"   # 512 K
 
 # Number of timer ticks per second (Hz). A timer tick may contain several timer
 # interrupts.

--- a/modules/ruxhal/src/arch/aarch64/trap.rs
+++ b/modules/ruxhal/src/arch/aarch64/trap.rs
@@ -9,8 +9,8 @@
 
 use core::arch::global_asm;
 
-#[cfg(feature = "irq")]
-use crate::arch::enable_irqs;
+#[cfg(all(feature = "irq", feature = "musl"))]
+use crate::arch::{disable_irqs, enable_irqs};
 #[cfg(feature = "paging")]
 use crate::trap::PageFaultCause;
 use aarch64_cpu::registers::{ESR_EL1, FAR_EL1};
@@ -74,6 +74,8 @@ fn handle_sync_exception(tf: &mut TrapFrame) {
                 ],
             );
             tf.r[0] = result as u64;
+            #[cfg(feature = "irq")]
+            disable_irqs();
         }
         Some(ESR_EL1::EC::Value::DataAbortLowerEL)
         | Some(ESR_EL1::EC::Value::InstrAbortLowerEL) => {


### PR DESCRIPTION
fix problems below:
1. mmap with `MAP_FIXED`: If the memory region specified by addr and length overlaps pages of any existing mapping(s), then the overlapped part of the existing mapping(s) will be discarded.
2. After the mmap() call has returned, the file descriptor, fd, can be closed immediately without invalidating the mapping.
3. disable_irq() before syscall handler restores registers, which prevent interruptions when restoring the registers.