### PR TITLE
update rustc version to nightly-1.76.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 profile = "minimal"
-channel = "nightly-2023-09-01"
+channel = "nightly-2023-12-01"
 components = ["rust-src", "llvm-tools-preview", "rustfmt", "clippy"]
 targets = ["x86_64-unknown-none", "riscv64gc-unknown-none-elf", "aarch64-unknown-none-softfloat"]


### PR DESCRIPTION
Update rustc version to `nightly-1.76.0` because of some unstable features for `cargo-binutils` dependencies. 