### PR TITLE
implement pagefault and tlb_flush for x86_64 to support mmap.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,7 @@ dependencies = [
  "bitmap-allocator",
  "buddy_system_allocator",
  "criterion",
+ "log",
  "rand",
  "rlsf",
  "slab_allocator",
@@ -1773,6 +1774,7 @@ name = "scheduler"
 version = "0.1.0"
 dependencies = [
  "linked_list",
+ "log",
 ]
 
 [[package]]

--- a/api/ruxos_posix_api/src/imp/mmap/mod.rs
+++ b/api/ruxos_posix_api/src/imp/mmap/mod.rs
@@ -8,7 +8,8 @@
  */
 
 cfg_if::cfg_if! {
-    if #[cfg(all(feature = "paging", target_arch = "aarch64"))] {
+    // for X86_64 with SMP, it must flush TLB via IPI
+    if #[cfg( all(feature = "paging", any(target_arch = "aarch64", any( all(target_arch = "x86_64", feature = "irq", feature = "smp"), all(target_arch = "x86_64", not(feature = "smp")) ) ) ))] {
         #[macro_use]
         mod utils;
         mod api;

--- a/api/ruxos_posix_api/src/imp/mmap/trap.rs
+++ b/api/ruxos_posix_api/src/imp/mmap/trap.rs
@@ -89,7 +89,7 @@ impl ruxhal::trap::TrapHandler for TrapHandlerImpl {
                 preload_page_with_swap(&mut memory_map, &mut swaped_map, &mut off_pool);
 
             // Fill target data to assigned physical addresses, from file or zero according to mapping type
-            let dst = fake_vaddr.as_mut_ptr();
+            let dst: *mut u8 = fake_vaddr.as_mut_ptr();
             #[cfg(feature = "fs")]
             {
                 if let Some(off) = swaped_map.remove(&vaddr) {

--- a/crates/allocator/Cargo.toml
+++ b/crates/allocator/Cargo.toml
@@ -22,6 +22,7 @@ buddy = ["dep:buddy_system_allocator"]
 allocator_api = []
 
 [dependencies]
+log = "0.4"
 buddy_system_allocator = { version = "0.9", default-features = false, optional = true }
 slab_allocator = { path = "../slab_allocator", optional = true }
 rlsf = { version = "0.2", optional = true }

--- a/crates/scheduler/Cargo.toml
+++ b/crates/scheduler/Cargo.toml
@@ -11,3 +11,4 @@ documentation = "https://rcore-os.github.io/arceos/scheduler/index.html"
 
 [dependencies]
 linked_list = { path = "../linked_list" }
+log = "0.4"

--- a/modules/ruxhal/src/arch/aarch64/trap.rs
+++ b/modules/ruxhal/src/arch/aarch64/trap.rs
@@ -96,18 +96,16 @@ fn handle_sync_exception(tf: &mut TrapFrame) {
 
                 // this cause is coded like linux.
                 let cause: PageFaultCause = match esr.read_as_enum(ESR_EL1::EC) {
-                    Some(ESR_EL1::EC::Value::DataAbortCurrentEL) => {
-                        if iss & 0x40 != 0 {
-                            PageFaultCause::WRITE // = store
-                        } else {
-                            PageFaultCause::READ //  = load
-                        }
+                    Some(ESR_EL1::EC::Value::DataAbortCurrentEL) if iss & 0x40 != 0 => {
+                        PageFaultCause::WRITE // = store
+                    }
+                    Some(ESR_EL1::EC::Value::DataAbortCurrentEL) if iss & 0x40 == 0 => {
+                        PageFaultCause::READ //  = load
                     }
                     _ => {
                         PageFaultCause::INSTRUCTION // = instruction fetch
                     }
                 };
-                debug!("mapped vaddr in Page Fault: {:X} {:?}", vaddr, cause);
                 if crate::trap::handle_page_fault(vaddr, cause) {
                     return;
                 }

--- a/modules/ruxhal/src/arch/x86_64/mod.rs
+++ b/modules/ruxhal/src/arch/x86_64/mod.rs
@@ -11,7 +11,6 @@ mod context;
 mod gdt;
 mod idt;
 
-#[cfg(target_os = "none")]
 mod trap;
 
 use core::arch::asm;
@@ -22,6 +21,20 @@ use x86_64::instructions::interrupts;
 
 #[cfg(feature = "musl")]
 use x86_64::registers::model_specific::EferFlags;
+
+#[cfg(feature = "irq")]
+extern crate alloc;
+
+#[cfg(all(feature = "irq", feature = "paging", feature = "smp"))]
+use {
+    crate::{
+        cpu::this_cpu_id,
+        platform::irq::{end_of_interrupt, send_ipi_excluding_self},
+    },
+    alloc::vec::Vec,
+    ruxconfig::SMP,
+    spinlock::SpinRaw,
+};
 
 pub use self::context::{ExtendedState, FxsaveArea, TaskContext, TrapFrame};
 pub use self::gdt::GdtStruct;
@@ -88,6 +101,27 @@ pub unsafe fn write_page_table_root(root_paddr: PhysAddr) {
     }
 }
 
+/// data structure for communicating between IPI for the TLB flushing.
+///
+/// `Vaddr` means flushing the TLB entry that maps the given virtual address.
+/// `All` means flushing the entire TLB.
+#[cfg(all(feature = "irq", feature = "paging", feature = "smp"))]
+enum FlushTlbIpiData {
+    Vaddr(usize),
+    All,
+}
+
+// const variable for every CPU's flushing addresses.
+#[cfg(all(feature = "irq", feature = "paging", feature = "smp"))]
+#[allow(clippy::declare_interior_mutable_const)]
+const FLUSH_QUEUES: SpinRaw<Vec<FlushTlbIpiData>> = SpinRaw::new(Vec::new());
+/// static variable for communicating between IPI for the TLB flushing.
+#[cfg(all(feature = "irq", feature = "paging", feature = "smp"))]
+static FLUSHING_ADDRESSES: [SpinRaw<Vec<FlushTlbIpiData>>; SMP] = [FLUSH_QUEUES; SMP];
+/// const irq vector for TLB flushing IPI.
+#[cfg(all(feature = "irq", feature = "paging", feature = "smp"))]
+pub const INVALID_TLB_VECTOR: u8 = 0xff; // SPURIOUS APIC INTERRUPT
+
 /// Flushes the TLB.
 ///
 /// If `vaddr` is [`None`], flushes the entire TLB. Otherwise, flushes the TLB
@@ -95,10 +129,66 @@ pub unsafe fn write_page_table_root(root_paddr: PhysAddr) {
 #[inline]
 pub fn flush_tlb(vaddr: Option<VirtAddr>) {
     if let Some(vaddr) = vaddr {
-        unsafe { tlb::flush(vaddr.into()) }
+        trace!("flush TLB entry: {:#x}", vaddr);
+        unsafe {
+            tlb::flush(vaddr.into());
+        }
+        #[cfg(all(feature = "irq", feature = "paging", feature = "smp"))]
+        {
+            for (i, flushing_vec) in FLUSHING_ADDRESSES.iter().enumerate().take(SMP) {
+                if i != this_cpu_id() {
+                    flushing_vec
+                        .lock()
+                        .push(FlushTlbIpiData::Vaddr(vaddr.into()));
+                }
+            }
+            unsafe {
+                send_ipi_excluding_self(INVALID_TLB_VECTOR);
+            }
+        }
     } else {
-        unsafe { tlb::flush_all() }
+        trace!("flush all TLB entry");
+        unsafe {
+            tlb::flush_all();
+        }
+        #[cfg(all(feature = "irq", feature = "paging", feature = "smp"))]
+        {
+            for (i, flushing_vec) in FLUSHING_ADDRESSES.iter().enumerate().take(SMP) {
+                if i != this_cpu_id() {
+                    let mut flushing_addresses = flushing_vec.lock();
+                    // clear all flushing addresses to avoid flushing again in IPI handler.
+                    flushing_addresses.clear();
+                    flushing_addresses.push(FlushTlbIpiData::All);
+                }
+            }
+            unsafe {
+                send_ipi_excluding_self(INVALID_TLB_VECTOR);
+            }
+        }
     }
+}
+
+/// Flushes the TLB in IPI handler.
+///
+/// This function is called in IPI handler, and it flushes the TLB entry that maps the given virtual address.
+#[inline]
+#[cfg(all(feature = "irq", feature = "paging", feature = "smp"))]
+pub(crate) fn flush_tlb_ipi_handler() {
+    // error!("flush TLB entry in IPI handler");
+    let guard = kernel_guard::NoPreempt::new();
+    unsafe {
+        let mut flushing_addresses = FLUSHING_ADDRESSES[this_cpu_id()].lock();
+        while let Some(flush_data) = flushing_addresses.pop() {
+            if let FlushTlbIpiData::Vaddr(vaddr) = flush_data {
+                tlb::flush(vaddr);
+            } else {
+                tlb::flush_all();
+                flushing_addresses.clear();
+            }
+        }
+        end_of_interrupt();
+    }
+    drop(guard);
 }
 
 /// Reads the thread pointer of the current CPU.

--- a/scripts/make/build_c.mk
+++ b/scripts/make/build_c.mk
@@ -29,6 +29,7 @@ endif
 
 ifeq ($(ARCH), x86_64)
   LDFLAGS += --no-relax
+  CFLAGS += -mno-red-zone
 else ifeq ($(ARCH), riscv64)
   CFLAGS += -march=rv64gc -mabi=lp64d -mcmodel=medany
 endif

--- a/scripts/make/build_musl.mk
+++ b/scripts/make/build_musl.mk
@@ -29,6 +29,7 @@ endif
 
 ifeq ($(ARCH), x86_64)
   LDFLAGS += --no-relax
+  CFLAGS += -mno-red-zone
 else ifeq ($(ARCH), riscv64)
   CFLAGS += -march=rv64gc -mabi=lp64d -mcmodel=medany
 endif

--- a/scripts/make/features.mk
+++ b/scripts/make/features.mk
@@ -18,7 +18,7 @@ ifeq ($(APP_TYPE),c)
   else
     lib_feat_prefix := ruxlibc/
   endif
-  lib_features := fp_simd alloc paging multitask fs net fd pipe select poll epoll random-hw signal
+  lib_features := fp_simd alloc irq sched_rr paging multitask fs net fd pipe select poll epoll random-hw signal
 else
   # TODO: it's better to use `ruxfeat/` as `ax_feat_prefix`, but all apps need to have `ruxfeat` as a dependency
   ax_feat_prefix := axstd/
@@ -27,7 +27,7 @@ else
 endif
 ifeq ($(APP_TYPE),c)
   ifeq ($(MUSL), y)
-    lib_features += irq musl sched_rr
+    lib_features += musl
   endif
 endif
 

--- a/ulib/ruxlibc/Cargo.toml
+++ b/ulib/ruxlibc/Cargo.toml
@@ -52,6 +52,11 @@ poll = ["ruxos_posix_api/poll"]
 epoll = ["ruxos_posix_api/epoll"]
 random-hw = ["ruxos_posix_api/random-hw"]
 
+# Interrupts
+irq = ["ruxos_posix_api/irq", "ruxfeat/irq"]
+
+sched_rr = ["irq", "ruxfeat/sched_rr"]
+
 [dependencies]
 ruxfeat = { path = "../../api/ruxfeat" }
 ruxos_posix_api = { path = "../../api/ruxos_posix_api" }


### PR DESCRIPTION
This PR implements #94 for x86_64. 
Note, both `irq` and `paging` are needed for x86_64 to use fully implemented mmap when SMP is enabled.