### PR TITLE
Implemented various backoffs and per-CPU rng

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1404,6 +1404,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "ratio"
 version = "0.1.0"
 
@@ -1796,6 +1805,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruxrand"
+version = "0.1.0"
+dependencies = [
+ "crate_interface",
+ "lazy_init",
+ "percpu",
+ "rand",
+ "rand_xoshiro",
+ "spinlock",
+]
+
+[[package]]
 name = "ruxruntime"
 version = "0.1.0"
 dependencies = [
@@ -1816,6 +1837,7 @@ dependencies = [
  "ruxfutex",
  "ruxhal",
  "ruxnet",
+ "ruxrand",
  "ruxtask",
  "tty",
 ]
@@ -1836,6 +1858,7 @@ dependencies = [
  "ruxconfig",
  "ruxfdtable",
  "ruxhal",
+ "ruxrand",
  "ruxtask",
  "scheduler",
  "spinlock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ members = [
     "modules/ruxruntime",
     "modules/ruxtask",
     "modules/ruxfutex",
+    "modules/ruxrand",
 
     "api/ruxfeat",
     "api/arceos_api",

--- a/crates/spinlock/Cargo.toml
+++ b/crates/spinlock/Cargo.toml
@@ -2,7 +2,10 @@
 name = "spinlock"
 version = "0.1.0"
 edition = "2021"
-authors = ["Yuekai Jia <equation618@gmail.com>"]
+authors = [
+    "Yuekai Jia <equation618@gmail.com>",
+    "Igna <Sssssaltyfish@gmail.com>",
+]
 description = "`no_std` spin lock implementation that can disable kernel local IRQs or preemption while locking"
 license = "GPL-3.0-or-later OR Apache-2.0"
 homepage = "https://github.com/rcore-os/arceos"

--- a/crates/spinlock/src/base.rs
+++ b/crates/spinlock/src/base.rs
@@ -24,17 +24,23 @@ use core::sync::atomic::{AtomicBool, Ordering};
 
 use kernel_guard::BaseGuard;
 
+use crate::{strategy, Strategy};
+
+/// The default strategy used in spinlocks.
+pub type DefaultStrategy = strategy::Once;
+
 /// A [spin lock](https://en.m.wikipedia.org/wiki/Spinlock) providing mutually
 /// exclusive access to data.
 ///
 /// This is a base struct, the specific behavior depends on the generic
 /// parameter `G` that implements [`BaseGuard`], such as whether to disable
-/// local IRQs or kernel preemption before acquiring the lock.
+/// local IRQs or kernel preemption before acquiring the lock. The parameter `S`
+/// that implements [`Strategy`] defines the behavior when encountering contention.
 ///
 /// For single-core environment (without the "smp" feature), we remove the lock
 /// state, CPU can always get the lock if we follow the proper guard in use.
-pub struct BaseSpinLock<G: BaseGuard, T: ?Sized> {
-    _phantom: PhantomData<G>,
+pub struct BaseSpinLock<DG: BaseGuard, T: ?Sized, S: Strategy = DefaultStrategy> {
+    _phantom: PhantomData<(DG, S)>,
     #[cfg(feature = "smp")]
     lock: AtomicBool,
     data: UnsafeCell<T>,
@@ -52,10 +58,10 @@ pub struct BaseSpinLockGuard<'a, G: BaseGuard, T: ?Sized + 'a> {
 }
 
 // Same unsafe impls as `std::sync::Mutex`
-unsafe impl<G: BaseGuard, T: ?Sized + Send> Sync for BaseSpinLock<G, T> {}
-unsafe impl<G: BaseGuard, T: ?Sized + Send> Send for BaseSpinLock<G, T> {}
+unsafe impl<G: BaseGuard, T: ?Sized + Send, B: Strategy> Sync for BaseSpinLock<G, T, B> {}
+unsafe impl<G: BaseGuard, T: ?Sized + Send, B: Strategy> Send for BaseSpinLock<G, T, B> {}
 
-impl<G: BaseGuard, T> BaseSpinLock<G, T> {
+impl<G: BaseGuard, T, S: Strategy> BaseSpinLock<G, T, S> {
     /// Creates a new [`BaseSpinLock`] wrapping the supplied data.
     #[inline(always)]
     pub const fn new(data: T) -> Self {
@@ -77,16 +83,20 @@ impl<G: BaseGuard, T> BaseSpinLock<G, T> {
     }
 }
 
-impl<G: BaseGuard, T: ?Sized> BaseSpinLock<G, T> {
-    /// Locks the [`BaseSpinLock`] and returns a guard that permits access to the inner data.
+impl<G: BaseGuard, T: ?Sized, S: Strategy> BaseSpinLock<G, T, S> {
+    /// Locks the [`BaseSpinLock`] using the given guard type and backoff strategy,
+    /// and returns a guard that permits access to the inner data.
     ///
     /// The returned value may be dereferenced for data access
     /// and the lock will be dropped when the guard falls out of scope.
-    #[inline(always)]
-    pub fn lock(&self) -> BaseSpinLockGuard<G, T> {
-        let irq_state = G::acquire();
+    pub fn lock_as<GT: BaseGuard, ST: Strategy>(&self) -> BaseSpinLockGuard<GT, T> {
+        let irq_state = GT::acquire();
+
         #[cfg(feature = "smp")]
         {
+            use crate::strategy::{Backoff, Relax};
+
+            let mut backoff = <ST as Strategy>::new_backoff();
             // Can fail to lock even if the spinlock is not locked. May be more efficient than `try_lock`
             // when called in a loop.
             while self
@@ -94,9 +104,12 @@ impl<G: BaseGuard, T: ?Sized> BaseSpinLock<G, T> {
                 .compare_exchange_weak(false, true, Ordering::Acquire, Ordering::Relaxed)
                 .is_err()
             {
+                backoff.backoff();
+                let mut relax = <ST as Strategy>::new_relax();
+
                 // Wait until the lock looks unlocked before retrying
                 while self.is_locked() {
-                    core::hint::spin_loop();
+                    relax.relax();
                 }
             }
         }
@@ -107,6 +120,16 @@ impl<G: BaseGuard, T: ?Sized> BaseSpinLock<G, T> {
             #[cfg(feature = "smp")]
             lock: &self.lock,
         }
+    }
+
+    /// Locks the [`BaseSpinLock`] using the "default" strategy specified by lock type,
+    /// and returns a guard that permits access to the inner data.
+    ///
+    /// The returned value may be dereferenced for data access
+    /// and the lock will be dropped when the guard falls out of scope.
+    #[inline(always)]
+    pub fn lock(&self) -> BaseSpinLockGuard<G, T> {
+        self.lock_as::<G, S>()
     }
 
     /// Returns `true` if the lock is currently held.
@@ -183,14 +206,14 @@ impl<G: BaseGuard, T: ?Sized> BaseSpinLock<G, T> {
     }
 }
 
-impl<G: BaseGuard, T: ?Sized + Default> Default for BaseSpinLock<G, T> {
+impl<G: BaseGuard, T: ?Sized + Default, S: Strategy> Default for BaseSpinLock<G, T, S> {
     #[inline(always)]
     fn default() -> Self {
         Self::new(Default::default())
     }
 }
 
-impl<G: BaseGuard, T: ?Sized + fmt::Debug> fmt::Debug for BaseSpinLock<G, T> {
+impl<G: BaseGuard, T: ?Sized + fmt::Debug, S: Strategy> fmt::Debug for BaseSpinLock<G, T, S> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.try_lock() {
             Some(guard) => write!(f, "SpinLock {{ data: ")

--- a/crates/spinlock/src/lib.rs
+++ b/crates/spinlock/src/lib.rs
@@ -16,14 +16,22 @@
 //!   environment (without this feature), the lock state is unnecessary and
 //!   optimized out. CPU can always get the lock if we follow the proper guard
 //!   in use. By default, this feature is disabled.
+//! - `rand`: Provide extra contention-alleviating strategy using exponential
+//!   backoff algorithm. The user is responsible for providing the random number
+//!   generator implementation.
 
 #![cfg_attr(not(test), no_std)]
 
 mod base;
 
-use kernel_guard::{NoOp, NoPreempt, NoPreemptIrqSave};
+/// Defines the strategies used when encountering lock contention.
+pub mod strategy;
+
+use kernel_guard::{NoPreempt, NoPreemptIrqSave};
 
 pub use self::base::{BaseSpinLock, BaseSpinLockGuard};
+
+pub use self::strategy::*;
 
 /// A spin lock that disables kernel preemption while trying to lock, and
 /// re-enables it after unlocking.
@@ -48,7 +56,7 @@ pub type SpinNoIrqGuard<'a, T> = BaseSpinLockGuard<'a, NoPreemptIrqSave, T>;
 ///
 /// It must be used in the preemption-disabled and local IRQ-disabled context,
 /// or never be used in interrupt handlers.
-pub type SpinRaw<T> = BaseSpinLock<NoOp, T>;
+pub type SpinRaw<T> = BaseSpinLock<kernel_guard::NoOp, T>;
 
 /// A guard that provides mutable data access for [`SpinRaw`].
-pub type SpinRawGuard<'a, T> = BaseSpinLockGuard<'a, NoOp, T>;
+pub type SpinRawGuard<'a, T> = BaseSpinLockGuard<'a, kernel_guard::NoOp, T>;

--- a/crates/spinlock/src/strategy.rs
+++ b/crates/spinlock/src/strategy.rs
@@ -1,0 +1,161 @@
+/* Copyright (c) [2023] [Syswonder Community]
+ *   [Ruxos] is licensed under Mulan PSL v2.
+ *   You can use this software according to the terms and conditions of the Mulan PSL v2.
+ *   You may obtain a copy of Mulan PSL v2 at:
+ *               http://license.coscl.org.cn/MulanPSL2
+ *   THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ *   See the Mulan PSL v2 for more details.
+ */
+
+use core::marker::PhantomData;
+
+// Re-exports extra strategies when feature enabled.
+#[cfg(feature = "rand")]
+pub use crate::rand_strategy::*;
+
+#[inline(always)]
+fn exp_backoff(current_limit: &mut u32, max: u32) {
+    let limit = *current_limit;
+    *current_limit = max.max(limit << 1);
+    for _ in 0..limit {
+        core::hint::spin_loop();
+    }
+}
+
+/// Defines the backoff behavior of a spinlock.
+pub trait Backoff {
+    /// Backoff behavior when failed to acquire the lock.
+    fn backoff(&mut self);
+}
+
+/// Defines the relax behavior of a spinlock.
+pub trait Relax {
+    /// Relax behavior when the lock seemed still held.
+    fn relax(&mut self);
+}
+
+/// Defines the lock behavior when encountering contention.
+/// [`Backoff::backoff`] is called when failed to acquire the lock, and
+/// [`Relax::relax`]` is called when the lock seemed still held.
+///
+/// One can easily define a new [`Strategy`] impl that
+/// combines existing backoff/relax behaviors.
+pub trait Strategy {
+    /// The type that defines the relax behavior.
+    type Relax: Relax;
+
+    /// The type that defines the backoff behavior.
+    type Backoff: Backoff;
+
+    /// Create a new relax state every time after failed to acquire the lock.
+    fn new_relax() -> Self::Relax;
+
+    /// Create a new backoff state every time after the locking procedure began.
+    fn new_backoff() -> Self::Backoff;
+}
+
+impl<T: Relax + Backoff + Default> Strategy for T {
+    type Relax = T;
+    type Backoff = T;
+
+    #[inline(always)]
+    fn new_relax() -> Self::Relax {
+        T::default()
+    }
+
+    #[inline(always)]
+    fn new_backoff() -> Self::Backoff {
+        T::default()
+    }
+}
+
+/// Do nothing when backoff/relax is required.
+/// It can be used as a baseline, or under rare circumstances be used as a
+/// performance improvement.
+///
+/// Note that under most modern CPU design, not using any backoff/relax strategy
+/// would normally make things slower.
+#[derive(Debug, Default)]
+pub struct NoOp;
+
+/// Call [`core::hint::spin_loop`] once when backoff/relax is required.
+///
+/// This may improve performance by said, reducing bus traffic. The exact
+/// behavior and benefits depend on the machine.
+#[derive(Debug, Default)]
+pub struct Once;
+
+/// Call [`core::hint::spin_loop`] with exponentially increased time when
+/// backoff/relax is required.
+///
+/// This would generally increase performance when the lock is highly contended.
+#[derive(Debug)]
+pub struct Exp<const MAX: u32>(u32);
+
+/// Combines a [`Relax`] and a [`Backoff`] into a strategy.
+#[derive(Debug, Default)]
+pub struct Combine<R: Relax, B: Backoff>(PhantomData<(R, B)>);
+
+impl Relax for NoOp {
+    #[inline(always)]
+    fn relax(&mut self) {}
+}
+
+impl Backoff for NoOp {
+    #[inline(always)]
+    fn backoff(&mut self) {}
+}
+
+impl Relax for Once {
+    #[inline(always)]
+    fn relax(&mut self) {
+        core::hint::spin_loop();
+    }
+}
+
+impl Backoff for Once {
+    #[inline(always)]
+    fn backoff(&mut self) {
+        core::hint::spin_loop();
+    }
+}
+
+impl<const N: u32> Relax for Exp<N> {
+    #[inline(always)]
+    fn relax(&mut self) {
+        exp_backoff(&mut self.0, N);
+    }
+}
+
+impl<const N: u32> Backoff for Exp<N> {
+    #[inline(always)]
+    fn backoff(&mut self) {
+        exp_backoff(&mut self.0, N);
+    }
+}
+
+impl<const N: u32> Default for Exp<N> {
+    #[inline(always)]
+    fn default() -> Self {
+        Self(1)
+    }
+}
+
+impl<R, B> Strategy for Combine<R, B>
+where
+    R: Relax + Default,
+    B: Backoff + Default,
+{
+    type Relax = R;
+    type Backoff = B;
+
+    #[inline(always)]
+    fn new_relax() -> Self::Relax {
+        R::default()
+    }
+
+    #[inline(always)]
+    fn new_backoff() -> Self::Backoff {
+        B::default()
+    }
+}

--- a/modules/ruxrand/Cargo.toml
+++ b/modules/ruxrand/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "ruxrand"
+version = "0.1.0"
+edition = "2021"
+authors = ["Sssssalty Fish <saltyfish2233@gmail.com>"]
+description = "RNG support for RuxOS"
+license = "GPL-3.0-or-later OR Apache-2.0"
+homepage = "https://github.com/syswonder/ruxos"
+repository = "https://github.com/rcore-os/arceos/tree/main/modules/ruxrand"
+
+[features]
+default = []
+
+easy-spin = []
+
+[dependencies]
+crate_interface = "0.1.1"
+rand = { version = "0.8.5", default-features = false }
+rand_xoshiro = { version = "0.6.0", default-features = false }
+
+spinlock = { version = "0.1.0", path = "../../crates/spinlock" }
+percpu = { version = "0.1.0", path = "../../crates/percpu" }
+lazy_init = { version = "0.1.0", path = "../../crates/lazy_init", default-features = false }
+
+[dev-dependencies]
+rand = { version = "0.8.5" }

--- a/modules/ruxrand/src/lib.rs
+++ b/modules/ruxrand/src/lib.rs
@@ -1,0 +1,39 @@
+/* Copyright (c) [2023] [Syswonder Community]
+ *   [Ruxos] is licensed under Mulan PSL v2.
+ *   You can use this software according to the terms and conditions of the Mulan PSL v2.
+ *   You may obtain a copy of Mulan PSL v2 at:
+ *               http://license.coscl.org.cn/MulanPSL2
+ *   THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ *   See the Mulan PSL v2 for more details.
+ */
+
+//! Runtime library of [Ruxos](https://github.com/syswonder/ruxos).
+//!
+//! This module provides the implementation of kernel-level random
+//! number generators (RNGs), especially the per-CPU RNG type. It also
+//! enables the usage of random exponential backoff strategy in spinlocks.
+//!
+//! # Cargo Features
+//!
+//! - `easy-spin`: Use a alternate, extremely simple RNG for backoff in
+//!   spinlocks, instead of the default per-CPU RNG. This may increase
+//!   performance when the lock is not highly contended.
+//!
+//! All the features are optional and disabled by default.
+
+#![cfg_attr(not(test), no_std)]
+#![feature(doc_cfg)]
+#![feature(doc_auto_cfg)]
+
+/// Defines the per-CPU RNG.
+pub mod rng;
+
+mod spin_rand;
+
+pub use rng::{percpu_rng, random, PercpuRng};
+pub use spin_rand::ExpRand;
+
+/// Initializes the per-CPU RNGs on the given CPU.
+pub fn init(cpuid: usize) {
+    rng::init(cpuid);
+}

--- a/modules/ruxrand/src/rng.rs
+++ b/modules/ruxrand/src/rng.rs
@@ -1,0 +1,157 @@
+/* Copyright (c) [2023] [Syswonder Community]
+ *   [Ruxos] is licensed under Mulan PSL v2.
+ *   You can use this software according to the terms and conditions of the Mulan PSL v2.
+ *   You may obtain a copy of Mulan PSL v2 at:
+ *               http://license.coscl.org.cn/MulanPSL2
+ *   THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ *   See the Mulan PSL v2 for more details.
+ */
+
+use lazy_init::LazyInit;
+use percpu::def_percpu;
+use rand::{distributions::Standard, prelude::*};
+use rand_xoshiro::Xoshiro256StarStar;
+
+#[allow(clippy::unusual_byte_groupings)]
+const RNG_SEED: u64 = 0xBAD_C0FFEE_0DD_F00D;
+
+type PercpuRngType = Xoshiro256StarStar;
+
+#[def_percpu]
+pub(crate) static PERCPU_RNG: LazyInit<PercpuRngType> = LazyInit::new();
+
+/// Initializes the per-CPU random number generator (RNG).
+///
+/// This function seeds the RNG with a hard-coded seed value and then performs a
+/// series of long jumps so that the random number sequence on each CPU is guaranteed to
+/// not overlap with each other.
+///
+/// A single [`PercpuRngType::long_jump`] skips 2^192 random numbers, providing sufficient
+/// space for randomness on each CPU.
+pub(crate) fn init(cpuid: usize) {
+    PERCPU_RNG.with_current(|percpu_ref| {
+        let mut rng = PercpuRngType::seed_from_u64(RNG_SEED);
+        for _ in 0..cpuid {
+            rng.long_jump();
+        }
+
+        percpu_ref.init_by(rng);
+    });
+}
+
+// Rationale for using a raw pointer in `PercpuRng`:
+//
+// Just like the case in `rand::thread_rng`, there will only
+// ever be one mutable reference generated from the mutable pointer, because
+// we only have such a reference inside `next_u32`, `next_u64`, etc. Within a
+// single processor (which is the definition of `PercpuRng`), there will only ever
+// be one of these methods active at a time.
+//
+// A possible scenario where there could be multiple mutable references is if
+// `PercpuRng` is used inside `next_u32` and co. But the implementation is
+// completely under our control. We just have to ensure none of them use
+// `PercpuRng` internally, which is nonsensical anyway. We should also never run
+// `PercpuRng` in destructors of its implementation, which is also nonsensical.
+//
+// Another possible scenario is that an interrupt happens at the middle of `next_u32`
+// or so, and the interrupt handler uses `PercpuRng`. This is indeed a violation of the
+// Rust aliasing model, but can hardly lead to any true hazard I think. It can be easily
+// fixed by requiring no IRQ using `kernel_guard` when implementing the functions provided
+// by `RngCore`.
+
+/// A RNG wrapper that's local to the calling CPU. The actual RNG type is
+/// `PercpuRngType`, which is currently [`Xoshiro256StarStar`].
+///
+/// This type is ! [`Send`] and ! [`Sync`], preventing potential misuse under
+/// SMP environments. Construct this type using [`Default::default`], or just
+/// a call to [`percpu_rng`].
+#[derive(Clone, Debug)]
+pub struct PercpuRng {
+    rng: *mut PercpuRngType,
+}
+
+impl PercpuRng {
+    fn get_rng(&mut self) -> &mut PercpuRngType {
+        unsafe { &mut *self.rng }
+    }
+}
+
+impl Default for PercpuRng {
+    fn default() -> Self {
+        percpu_rng()
+    }
+}
+
+impl RngCore for PercpuRng {
+    #[inline(always)]
+    fn next_u32(&mut self) -> u32 {
+        self.get_rng().next_u32()
+    }
+
+    #[inline(always)]
+    fn next_u64(&mut self) -> u64 {
+        self.get_rng().next_u64()
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.get_rng().fill_bytes(dest)
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
+        self.get_rng().try_fill_bytes(dest)
+    }
+}
+
+impl CryptoRng for PercpuRng {}
+
+/// Retrieves the per-CPU RNG [`PercpuRng`] that points to the CPU-local RNG states.
+///
+/// The RNGs were initialized by the same seed, but jumped to different locations in
+/// the pseudo-random sequence, effectively making the RNG independently and identically
+/// distributed on all CPUs.
+pub fn percpu_rng() -> PercpuRng {
+    // It is unsafe to return mutable pointer to a global data structure
+    // without preemption disabled, but the baddest thing that can happen whatsoever
+    // here is the rng being put into some "random" state, which I think is not fatal.
+    let rng = unsafe { PERCPU_RNG.current_ref_mut_raw().get_mut_unchecked() as *mut _ };
+    PercpuRng { rng }
+}
+
+/// Generates a random value using the per-CPU random number generator.
+///
+/// This is simply a shortcut for `percpu_rng().gen()`. See [`percpu_rng`] for
+/// documentation of the entropy source and [`Standard`] for documentation of
+/// distributions and type-specific generation.
+///
+/// # Provided implementations
+///
+/// The following types have provided implementations that
+/// generate values with the following ranges and distributions:
+///
+/// * Integers (`i32`, `u32`, `isize`, `usize`, etc.): Uniformly distributed
+///   over all values of the type.
+/// * `char`: Uniformly distributed over all Unicode scalar values, i.e. all
+///   code points in the range `0...0x10_FFFF`, except for the range
+///   `0xD800...0xDFFF` (the surrogate code points). This includes
+///   unassigned/reserved code points.
+/// * `bool`: Generates `false` or `true`, each with probability 0.5.
+/// * Floating point types (`f32` and `f64`): Uniformly distributed in the
+///   half-open range `[0, 1)`. See notes below.
+/// * Wrapping integers (`Wrapping<T>`), besides the type identical to their
+///   normal integer variants.
+///
+/// Also supported is the generation of the following
+/// compound types where all component types are supported:
+///
+/// *   Tuples (up to 12 elements): each element is generated sequentially.
+/// *   Arrays (up to 32 elements): each element is generated sequentially;
+///     see also [`Rng::fill`] which supports arbitrary array length for integer
+///     types and tends to be faster for `u32` and smaller types.
+/// *   `Option<T>` first generates a `bool`, and if true generates and returns
+///     `Some(value)` where `value: T`, otherwise returning `None`.
+pub fn random<T>() -> T
+where
+    Standard: Distribution<T>,
+{
+    percpu_rng().gen()
+}

--- a/modules/ruxrand/src/spin_rand.rs
+++ b/modules/ruxrand/src/spin_rand.rs
@@ -1,0 +1,109 @@
+/* Copyright (c) [2023] [Syswonder Community]
+ *   [Ruxos] is licensed under Mulan PSL v2.
+ *   You can use this software according to the terms and conditions of the Mulan PSL v2.
+ *   You may obtain a copy of Mulan PSL v2 at:
+ *               http://license.coscl.org.cn/MulanPSL2
+ *   THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ *   See the Mulan PSL v2 for more details.
+ */
+
+use core::{
+    fmt::Debug,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+use rand::RngCore;
+use spinlock::{Backoff, Relax};
+
+#[cfg(feature = "easy-spin")]
+type SpinRng = EasyRng;
+
+#[cfg(not(feature = "easy-spin"))]
+type SpinRng = crate::rng::PercpuRng;
+
+#[inline(always)]
+fn exp_rand_backoff(current_limit: &mut u32, max: u32) {
+    let limit = *current_limit;
+    *current_limit = max.max(limit);
+
+    let mut rng = SpinRng::default();
+    // It is more "correct" to use `rng.gen_range(0..limit)`,
+    // but since `limit` would only be powers of two, a simple
+    // modulo would also keep the distribution uniform as long
+    // as `rng.next_u32()` keeps a uniform distribution on `u32`.
+    let delay = rng.next_u32() % limit;
+    for _ in 0..delay {
+        core::hint::spin_loop();
+    }
+}
+
+/// Calls [`core::hint::spin_loop`] random times within an exponentially grown limit
+/// when backoff/relax is required. The random number is generated using [`RngCore::next_u32`],
+/// and the actual rng used is controlled by the `easy-spin` feature.
+///
+/// This would generally increase performance when the lock is highly contended.
+#[derive(Debug)]
+pub struct ExpRand<const MAX: u32>(u32);
+
+impl<const N: u32> Relax for ExpRand<N> {
+    #[inline(always)]
+    fn relax(&mut self) {
+        exp_rand_backoff(&mut self.0, N);
+    }
+}
+
+impl<const N: u32> Backoff for ExpRand<N> {
+    #[inline(always)]
+    fn backoff(&mut self) {
+        exp_rand_backoff(&mut self.0, N);
+    }
+}
+
+impl<const N: u32> Default for ExpRand<N> {
+    #[inline(always)]
+    fn default() -> Self {
+        Self(1)
+    }
+}
+
+#[derive(Clone, Default)]
+struct EasyRng;
+
+impl Debug for EasyRng {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let state = EASY_RNG_STATE.load(Ordering::Relaxed);
+        f.debug_struct("EasyRng").field("state", &state).finish()
+    }
+}
+
+impl RngCore for EasyRng {
+    fn next_u32(&mut self) -> u32 {
+        easy_rng()
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        easy_rng() as _
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        dest.fill_with(|| easy_rng() as _)
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
+        dest.fill_with(|| easy_rng() as _);
+        Ok(())
+    }
+}
+
+static EASY_RNG_STATE: AtomicUsize = AtomicUsize::new(0);
+
+fn easy_rng() -> u32 {
+    const RANDOM_RANDOM_LIST: [u8; 64] = [
+        9, 7, 13, 0, 15, 2, 14, 1, 14, 14, 11, 3, 13, 11, 12, 10, 3, 6, 8, 1, 2, 0, 12, 12, 13, 2,
+        9, 5, 3, 10, 6, 1, 15, 9, 6, 12, 9, 7, 4, 7, 4, 8, 11, 7, 0, 1, 2, 10, 15, 6, 5, 3, 0, 5,
+        14, 4, 4, 13, 15, 8, 5, 10, 8, 11,
+    ];
+
+    let idx = EASY_RNG_STATE.fetch_add(1, Ordering::Relaxed) % RANDOM_RANDOM_LIST.len();
+    RANDOM_RANDOM_LIST[idx] as _
+}

--- a/modules/ruxruntime/Cargo.toml
+++ b/modules/ruxruntime/Cargo.toml
@@ -23,7 +23,8 @@ alloc = ["axalloc", "dtb"]
 paging = ["ruxhal/paging", "lazy_init"]
 rtc = ["ruxhal/rtc"]
 
-multitask = ["ruxtask/multitask", "dep:ruxfutex"]
+multitask = ["ruxtask/multitask", "dep:ruxfutex", "rand"]
+rand = ["dep:ruxrand"]
 fs = ["ruxdriver", "ruxfs"]
 blkfs = ["fs"]
 virtio-9p = ["fs", "rux9p"]
@@ -49,6 +50,7 @@ ruxdisplay = { path = "../ruxdisplay", optional = true }
 ruxtask = { path = "../ruxtask", optional = true }
 axsync = { path = "../axsync", optional = true }
 ruxfutex = { path = "../ruxfutex", optional = true }
+ruxrand = { path = "../ruxrand", optional = true }
 
 crate_interface = "0.1.1"
 percpu = { path = "../../crates/percpu", optional = true }

--- a/modules/ruxruntime/src/lib.rs
+++ b/modules/ruxruntime/src/lib.rs
@@ -201,6 +201,9 @@ pub extern "C" fn rust_main(cpu_id: usize, dtb: usize) -> ! {
     info!("Initialize platform devices...");
     ruxhal::platform_init();
 
+    #[cfg(feature = "rand")]
+    ruxrand::init(cpu_id);
+
     #[cfg(feature = "multitask")]
     {
         ruxtask::init_scheduler();

--- a/modules/ruxruntime/src/mp.rs
+++ b/modules/ruxruntime/src/mp.rs
@@ -48,6 +48,9 @@ pub extern "C" fn rust_main_secondary(cpu_id: usize) -> ! {
 
     ruxhal::platform_init_secondary();
 
+    #[cfg(feature = "rand")]
+    ruxrand::init(cpu_id);
+
     #[cfg(feature = "multitask")]
     ruxtask::init_scheduler_secondary();
 

--- a/modules/ruxtask/Cargo.toml
+++ b/modules/ruxtask/Cargo.toml
@@ -2,10 +2,7 @@
 name = "ruxtask"
 version = "0.1.0"
 edition = "2021"
-authors = [
-    "Yuekai Jia <equation618@gmail.com>",
-    "AuYang261 <xu_jyang@163.com>",
-]
+authors = ["Yuekai Jia <equation618@gmail.com>", "AuYang261 <xu_jyang@163.com>"]
 description = "Ruxos task management module"
 license = "GPL-3.0-or-later OR Apache-2.0"
 homepage = "https://github.com/syswonder/ruxos"
@@ -15,8 +12,16 @@ repository = "https://github.com/syswonder/ruxos/tree/main/modules/ruxtask"
 default = []
 
 multitask = [
-    "dep:ruxconfig", "dep:percpu", "dep:spinlock", "dep:lazy_init", "dep:memory_addr",
-    "dep:scheduler", "dep:timer_list", "kernel_guard", "dep:crate_interface",
+    "dep:ruxconfig",
+    "dep:ruxrand",
+    "dep:percpu",
+    "dep:spinlock",
+    "dep:lazy_init",
+    "dep:memory_addr",
+    "dep:scheduler",
+    "dep:timer_list",
+    "dep:crate_interface",
+    "dep:kernel_guard",
 ]
 irq = []
 tls = ["ruxhal/tls"]
@@ -34,8 +39,10 @@ cfg-if = "1.0"
 log = "0.4"
 axerrno = { path = "../../crates/axerrno" }
 ruxhal = { path = "../ruxhal" }
-ruxconfig = { path = "../ruxconfig", optional = true }
 ruxfdtable = { path = "../ruxfdtable" }
+ruxconfig = { path = "../ruxconfig", optional = true }
+ruxrand = { path = "../ruxrand", optional = true }
+
 percpu = { path = "../../crates/percpu", optional = true }
 spinlock = { path = "../../crates/spinlock", optional = true }
 lazy_init = { path = "../../crates/lazy_init", optional = true }

--- a/modules/ruxtask/src/run_queue.rs
+++ b/modules/ruxtask/src/run_queue.rs
@@ -10,16 +10,22 @@
 use alloc::collections::VecDeque;
 use alloc::sync::Arc;
 use axerrno::{LinuxError, LinuxResult};
+use kernel_guard::NoPreemptIrqSave;
 use lazy_init::LazyInit;
 use ruxfdtable::{FD_TABLE, RUX_FILE_LIMIT};
+use ruxrand::ExpRand;
 use scheduler::BaseScheduler;
-use spinlock::SpinNoIrq;
+use spinlock::{BaseSpinLock, Combine, SpinNoIrq};
 
 use crate::task::{CurrentTask, TaskState};
 use crate::{AxTaskRef, Scheduler, TaskInner, WaitQueue};
 
+pub(crate) const BACKOFF_LIMIT: u32 = 8;
+pub(crate) type DefaultStrategy = Combine<ExpRand<BACKOFF_LIMIT>, spinlock::NoOp>;
+pub(crate) type RQLock<T> = BaseSpinLock<NoPreemptIrqSave, T, DefaultStrategy>;
+
 // TODO: per-CPU
-pub(crate) static RUN_QUEUE: LazyInit<SpinNoIrq<AxRunQueue>> = LazyInit::new();
+pub(crate) static RUN_QUEUE: LazyInit<RQLock<AxRunQueue>> = LazyInit::new();
 
 // TODO: per-CPU
 static EXITED_TASKS: SpinNoIrq<VecDeque<AxTaskRef>> = SpinNoIrq::new(VecDeque::new());
@@ -34,11 +40,11 @@ pub(crate) struct AxRunQueue {
 }
 
 impl AxRunQueue {
-    pub fn new() -> SpinNoIrq<Self> {
+    pub fn new() -> RQLock<Self> {
         let gc_task = TaskInner::new(gc_entry, "gc".into(), ruxconfig::TASK_STACK_SIZE);
         let mut scheduler = Scheduler::new();
         scheduler.add_task(gc_task);
-        SpinNoIrq::new(Self { scheduler })
+        RQLock::new(Self { scheduler })
     }
 
     pub fn add_task(&mut self, task: AxTaskRef) {


### PR DESCRIPTION
1. Modified crates/spinlock to provide support for multiple backoff strategies when encountering lock contention, including exp-backoff and rand-exp-backoff.

2. Modified `BaseSpinLock` in crates/spinlock to support locking with a different guard/backoff type, providing more flexibility.

3. Added a new module `ruxrand` that aims to provide support for the usage of RNGs inside kernel. Currently a per-CPU RNG and support for rand-exp-backoff in spinlock are implemented.

4. Changed the lock type used by `RunQueue`.