### PR TITLE
fix bugs for multiprocess in aarch64.

### DIFF
--- a/api/ruxos_posix_api/src/imp/pthread/mod.rs
+++ b/api/ruxos_posix_api/src/imp/pthread/mod.rs
@@ -226,6 +226,18 @@ pub fn sys_pthread_exit(retval: *mut c_void) -> ! {
     Pthread::exit_current(retval);
 }
 
+/// Exits the current thread. The value `retval` will be returned to the joiner.
+pub fn sys_exit_group(status: c_int) -> ! {
+    error!("sys_exit_group <= {:#?}", status);
+
+    // TODO: exit all threads, send signal to all threads
+
+    #[cfg(feature = "multitask")]
+    ruxtask::exit(status);
+    #[cfg(not(feature = "multitask"))]
+    ruxhal::misc::terminate();
+}
+
 /// Waits for the given thread to exit, and stores the return value in `retval`.
 pub unsafe fn sys_pthread_join(thread: ctypes::pthread_t, retval: *mut *mut c_void) -> c_int {
     debug!("sys_pthread_join <= {:#x}", retval as usize);

--- a/api/ruxos_posix_api/src/imp/task.rs
+++ b/api/ruxos_posix_api/src/imp/task.rs
@@ -63,7 +63,7 @@ pub fn sys_wait4(
 ) -> c_int {
     const WNOHANG: c_int = 0x00000001;
 
-    error!(
+    debug!(
         "sys_wait4 <= pid: {}, wstatus: {:?}, options: {}, rusage: {:?}",
         pid, wstatus, options, rusage
     );
@@ -73,6 +73,12 @@ pub fn sys_wait4(
             let mut process_map = PROCESS_MAP.lock();
             if let Some(task) = process_map.get(&(pid as u64)) {
                 if task.state() == ruxtask::task::TaskState::Exited {
+                    unsafe {
+                        // lower 8 bits of exit_code is the signal number, while upper 8 bits of exit_code is the exit status
+                        // according to "bits/waitstatus.h" in glibc source code.
+                        // TODO: add signal number to wstatus
+                        wstatus.write(task.exit_code()<<8);
+                    }
                     process_map.remove(&(pid as u64));
                     return pid;
                 } else if options & WNOHANG != 0 {
@@ -98,6 +104,13 @@ pub fn sys_wait4(
                 if parent_pid == ruxtask::current().id().as_u64() {
                     if task.state() == ruxtask::task::TaskState::Exited {
                         // add to to_remove list
+                        let task_ref = process_map.get(child_pid).unwrap();
+                        unsafe {
+                            // lower 8 bits of exit_code is the signal number, while upper 8 bits of exit_code is the exit status
+                            // according to "bits/waitstatus.h" in glibc source code.
+                            // TODO: add signal number to wstatus
+                            wstatus.write(task.exit_code()<<8);
+                        }
                         let _ = to_remove.insert(*child_pid);
                         break;
                     }
@@ -108,6 +121,10 @@ pub fn sys_wait4(
             }
             // drop lock before yielding to other tasks
             drop(process_map);
+            // check if the condition is meet
+            if !to_remove.is_none() {
+                break;
+            }
             // for single-cpu system, we must yield to other tasks instead of dead-looping here.
             yield_now();
         }

--- a/api/ruxos_posix_api/src/imp/task.rs
+++ b/api/ruxos_posix_api/src/imp/task.rs
@@ -54,7 +54,7 @@ pub fn sys_getppid() -> c_int {
 
 /// Wait for a child process to exit and return its status.
 ///
-/// TOSO, wstatus, options, and rusage are not implemented yet.
+/// TODO: part of options, and rusage are not implemented yet.
 pub fn sys_wait4(
     pid: c_int,
     wstatus: *mut c_int,
@@ -104,7 +104,6 @@ pub fn sys_wait4(
                 if parent_pid == ruxtask::current().id().as_u64() {
                     if task.state() == ruxtask::task::TaskState::Exited {
                         // add to to_remove list
-                        let task_ref = process_map.get(child_pid).unwrap();
                         unsafe {
                             // lower 8 bits of exit_code is the signal number, while upper 8 bits of exit_code is the exit status
                             // according to "bits/waitstatus.h" in glibc source code.

--- a/api/ruxos_posix_api/src/lib.rs
+++ b/api/ruxos_posix_api/src/lib.rs
@@ -117,7 +117,7 @@ pub use imp::pthread::sys_clone;
 #[cfg(all(feature = "multitask", feature = "musl"))]
 pub use imp::pthread::sys_set_tid_address;
 #[cfg(feature = "multitask")]
-pub use imp::pthread::{sys_pthread_create, sys_pthread_exit, sys_pthread_join, sys_pthread_self};
+pub use imp::pthread::{sys_pthread_create, sys_pthread_exit, sys_exit_group, sys_pthread_join, sys_pthread_self};
 
 #[cfg(feature = "fs")]
 pub use imp::execve::sys_execve;

--- a/crates/percpu/src/imp.rs
+++ b/crates/percpu/src/imp.rs
@@ -8,8 +8,9 @@
  */
 
 const fn align_up(val: usize) -> usize {
-    const PAGE_SIZE: usize = 0x1000;
-    (val + PAGE_SIZE - 1) & !(PAGE_SIZE - 1)
+    // should be the same as align_size in percpu.
+    const ALIGN_SIZE: usize = 64;
+    (val + ALIGN_SIZE - 1) & !(ALIGN_SIZE - 1)
 }
 
 #[cfg(not(target_os = "none"))]

--- a/modules/ruxtask/src/fs.rs
+++ b/modules/ruxtask/src/fs.rs
@@ -216,6 +216,16 @@ pub struct FileSystem {
     pub root_dir: Arc<RootDirectory>,
 }
 
+impl FileSystem {
+    pub fn close_all_files(&mut self) {
+        for fd in 0..self.fd_table.capacity() {
+            if let Some(_) = self.fd_table.get(fd) {
+                self.fd_table.remove(fd).unwrap();
+            }
+        }
+    }
+}
+
 impl Clone for FileSystem {
     fn clone(&self) -> Self {
         let mut new_fd_table = FlattenObjects::new();

--- a/ulib/ruxmusl/src/aarch64/mod.rs
+++ b/ulib/ruxmusl/src/aarch64/mod.rs
@@ -201,6 +201,9 @@ pub fn syscall(syscall_id: SyscallId, args: [usize; 6]) -> isize {
             SyscallId::EXIT => {
                 ruxos_posix_api::sys_pthread_exit(args[0] as *mut core::ffi::c_void) as _
             }
+            SyscallId::EXIT_GROUP => {
+                ruxos_posix_api::sys_exit_group(args[0] as c_int)
+            }            
             #[cfg(feature = "multitask")]
             SyscallId::SET_TID_ADDRESS => ruxos_posix_api::sys_set_tid_address(args[0]) as _,
             #[cfg(feature = "multitask")]

--- a/ulib/ruxmusl/src/aarch64/syscall_id.rs
+++ b/ulib/ruxmusl/src/aarch64/syscall_id.rs
@@ -73,6 +73,7 @@ pub enum SyscallId {
     FDATASYNC = 83,
     CAP_GET = 90,
     EXIT = 93,
+    EXIT_GROUP = 94,
     #[cfg(feature = "multitask")]
     SET_TID_ADDRESS = 96,
     #[cfg(feature = "multitask")]


### PR DESCRIPTION
1. deadlock when `SMP>1`.
2. wrong judgement for pipe's write end closure.
3. unclosed files when `sys_exit_group` .