### PR TITLE
feat: implement syscall sys_socketpair

### DIFF
--- a/api/ruxos_posix_api/src/imp/io_mpx/poll.rs
+++ b/api/ruxos_posix_api/src/imp/io_mpx/poll.rs
@@ -75,6 +75,7 @@ pub unsafe fn sys_poll(fds: *mut ctypes::pollfd, nfds: ctypes::nfds_t, timeout: 
             return Err(LinuxError::EINVAL);
         }
         let fds = core::slice::from_raw_parts_mut(fds, nfds as usize);
+        debug!("[sys_poll] monitored fds is {:?}", fds);
         let deadline = (!timeout.is_negative())
             .then(|| current_time() + Duration::from_millis(timeout as u64));
         for pollfd_item in fds.iter_mut() {

--- a/api/ruxos_posix_api/src/imp/pipe.rs
+++ b/api/ruxos_posix_api/src/imp/pipe.rs
@@ -243,6 +243,7 @@ pub fn sys_pipe(fds: &mut [c_int]) -> c_int {
         fds[0] = read_fd as c_int;
         fds[1] = write_fd as c_int;
 
+        debug!("[sys_pipe] create pipe with read fd {read_fd} and write fd {write_fd}");
         Ok(0)
     })
 }

--- a/api/ruxos_posix_api/src/imp/resources.rs
+++ b/api/ruxos_posix_api/src/imp/resources.rs
@@ -81,9 +81,17 @@ pub unsafe fn sys_setrlimit(resource: c_int, rlimits: *const ctypes::rlimit) -> 
     debug!("sys_setrlimit <= {} {:#x}", resource, rlimits as usize);
     syscall_body!(sys_setrlimit, {
         match resource as u32 {
+            ctypes::RLIMIT_FSIZE => {
+                warn!("[sys_setrlimit] set RLIMIT_FSIZE do nothing")
+            }
             ctypes::RLIMIT_DATA => {}
             ctypes::RLIMIT_STACK => {}
-            ctypes::RLIMIT_NOFILE => {}
+            ctypes::RLIMIT_NOFILE => {
+                warn!("[sys_setrlimit] set RLIMIT_NOFILE do nothing")
+            }
+            ctypes::RLIMIT_NPROC => {
+                warn!("[sys_setrlimit] set RLIMIT_NPROC do nothing")
+            }
             _ => return Err(LinuxError::EINVAL),
         }
         // Currently do not support set resources

--- a/api/ruxos_posix_api/src/lib.rs
+++ b/api/ruxos_posix_api/src/lib.rs
@@ -89,7 +89,7 @@ pub use imp::mmap::{sys_madvise, sys_mmap, sys_mprotect, sys_mremap, sys_msync, 
 pub use imp::net::{
     sys_accept, sys_bind, sys_connect, sys_freeaddrinfo, sys_getaddrinfo, sys_getpeername,
     sys_getsockname, sys_getsockopt, sys_listen, sys_recv, sys_recvfrom, sys_send, sys_sendmsg,
-    sys_sendto, sys_setsockopt, sys_shutdown, sys_socket,
+    sys_sendto, sys_setsockopt, sys_shutdown, sys_socket, sys_socketpair,
 };
 #[cfg(feature = "pipe")]
 pub use imp::pipe::{sys_pipe, sys_pipe2};

--- a/modules/ruxnet/src/unix.rs
+++ b/modules/ruxnet/src/unix.rs
@@ -597,8 +597,11 @@ impl UnixSocket {
                     match remote_handle {
                         Some(handle) => {
                             let mut binding = UNIX_TABLE.write();
-                            let remote_status = binding.get_mut(handle).unwrap().lock().get_state();
-                            remote_status == UnixSocketStatus::Closed
+                            if let Some(inner) = binding.get_mut(handle) {
+                                inner.lock().get_state() == UnixSocketStatus::Closed
+                            } else {
+                                true
+                            }
                         }
                         None => {
                             return Err(LinuxError::ENOTCONN);

--- a/modules/ruxnet/src/unix.rs
+++ b/modules/ruxnet/src/unix.rs
@@ -300,6 +300,48 @@ impl UnixSocket {
         }
     }
 
+    /// Creates a pair of Unix domain sockets and establishes their connection based on the specified socket type.
+    ///
+    /// For `SOCK_STREAM`, the sockets are connected and marked as "connected" in the UNIX_TABLE.
+    /// For `SOCK_DGRAM`, the sockets are assigned each other's address as their peer address.
+    ///
+    /// Returns:
+    ///
+    /// A result containing a tuple of two connected `UnixSocket` instances on success.
+    /// If the connection setup fails, an error is returned.
+    pub fn create_socket_pair(_type: UnixSocketType) -> AxResult<(Self, Self)> {
+        let sk1 = UnixSocket::new(_type);
+        let sk2 = UnixSocket::new(_type);
+        let handle1 = sk1.get_sockethandle();
+        let handle2 = sk2.get_sockethandle();
+        match _type {
+            UnixSocketType::SockStream => {
+                let mut binding = UNIX_TABLE.write();
+                let mut inner1 = binding.get_mut(handle1).unwrap().lock();
+                inner1.set_peersocket(handle2);
+                inner1.set_state(UnixSocketStatus::Connected);
+                drop(inner1);
+                let mut inner2 = binding.get_mut(handle2).unwrap().lock();
+                inner2.set_peersocket(handle1);
+                inner2.set_state(UnixSocketStatus::Connected);
+            }
+            UnixSocketType::SockDgram => {
+                let addr1 = sk1.check_and_set_addr();
+                let addr2 = sk2.check_and_set_addr();
+                let mut binding = UNIX_TABLE.write();
+                let mut inner1 = binding.get_mut(handle1).unwrap().lock();
+                inner1.set_peersocket(handle2);
+                inner1.dgram_connected_addr = Some(addr2);
+                drop(inner1);
+                let mut inner2 = binding.get_mut(handle2).unwrap().lock();
+                inner2.set_peersocket(handle1);
+                inner2.dgram_connected_addr = Some(addr1);
+            }
+            UnixSocketType::SockSeqpacket => todo!(),
+        }
+        Ok((sk1, sk2))
+    }
+
     /// Sets the socket handle.
     pub fn set_sockethandle(&mut self, fd: usize) {
         self.sockethandle = Some(fd);

--- a/ulib/ruxmusl/src/aarch64/mod.rs
+++ b/ulib/ruxmusl/src/aarch64/mod.rs
@@ -288,6 +288,13 @@ pub fn syscall(syscall_id: SyscallId, args: [usize; 6]) -> isize {
                     as _
             }
             #[cfg(feature = "net")]
+            SyscallId::SOCKETPAIR => ruxos_posix_api::sys_socketpair(
+                args[0] as _,
+                args[1] as _,
+                args[2] as _,
+                core::slice::from_raw_parts_mut(args[3] as *mut c_int, 2),
+            ) as _,
+            #[cfg(feature = "net")]
             SyscallId::BIND => ruxos_posix_api::sys_bind(
                 args[0] as c_int,
                 args[1] as *const ctypes::sockaddr,

--- a/ulib/ruxmusl/src/aarch64/syscall_id.rs
+++ b/ulib/ruxmusl/src/aarch64/syscall_id.rs
@@ -115,6 +115,8 @@ pub enum SyscallId {
     #[cfg(feature = "net")]
     SOCKET = 198,
     #[cfg(feature = "net")]
+    SOCKETPAIR = 199,
+    #[cfg(feature = "net")]
     BIND = 200,
     #[cfg(feature = "net")]
     LISTEN = 201,

--- a/ulib/ruxmusl/src/riscv64/mod.rs
+++ b/ulib/ruxmusl/src/riscv64/mod.rs
@@ -238,6 +238,13 @@ pub fn syscall(syscall_id: SyscallId, args: [usize; 6]) -> isize {
                     as _
             }
             #[cfg(feature = "net")]
+            SyscallId::SOCKETPAIR => ruxos_posix_api::sys_socketpair(
+                args[0] as _,
+                args[1] as _,
+                args[2] as _,
+                core::slice::from_raw_parts_mut(args[3] as *mut c_int, 2),
+            ) as _,
+            #[cfg(feature = "net")]
             SyscallId::BIND => ruxos_posix_api::sys_bind(
                 args[0] as c_int,
                 args[1] as *const ctypes::sockaddr,

--- a/ulib/ruxmusl/src/riscv64/syscall_id.rs
+++ b/ulib/ruxmusl/src/riscv64/syscall_id.rs
@@ -89,6 +89,8 @@ pub enum SyscallId {
     #[cfg(feature = "net")]
     SOCKET = 198,
     #[cfg(feature = "net")]
+    SOCKETPAIR = 199,
+    #[cfg(feature = "net")]
     BIND = 200,
     #[cfg(feature = "net")]
     LISTEN = 201,

--- a/ulib/ruxmusl/src/x86_64/mod.rs
+++ b/ulib/ruxmusl/src/x86_64/mod.rs
@@ -192,7 +192,13 @@ pub fn syscall(syscall_id: SyscallId, args: [usize; 6]) -> isize {
                 ruxos_posix_api::sys_socket(args[0] as c_int, args[1] as c_int, args[2] as c_int)
                     as _
             }
-
+            #[cfg(feature = "net")]
+            SyscallId::SOCKETPAIR => ruxos_posix_api::sys_socketpair(
+                args[0] as _,
+                args[1] as _,
+                args[2] as _,
+                core::slice::from_raw_parts_mut(args[3] as *mut c_int, 2),
+            ) as _,
             #[cfg(feature = "net")]
             SyscallId::CONNECT => ruxos_posix_api::sys_connect(
                 args[0] as c_int,

--- a/ulib/ruxmusl/src/x86_64/syscall_id.rs
+++ b/ulib/ruxmusl/src/x86_64/syscall_id.rs
@@ -124,6 +124,9 @@ pub enum SyscallId {
     GETPEERNAME = 52,
 
     #[cfg(feature = "net")]
+    SOCKETPAIR = 53,
+
+    #[cfg(feature = "net")]
     SETSOCKOPT = 54,
 
     #[cfg(feature = "net")]


### PR DESCRIPTION
Implement the `sys_socketpair` syscall to create a pair of connected UNIX domain sockets (AF_UNIX) for inter-process communication. Similar to pipes, it provides a communication channel between related processes, such as parent-child processes. However, unlike pipes, socket pairs offer more flexibility, supporting full-duplex communication and allowing for more complex messaging. It does not support network communication (e.g., AF_INET or AF_INET6).

There is an test program to check if this syscall works:

```c
#include <stdio.h>
#include <stdlib.h>
#include <sys/socket.h>
#include <sys/types.h>
#include <sys/un.h>
#include <sys/wait.h>
#include <unistd.h>
#include <sys/select.h>

// Test if two stream sockets can read and write to each other
void test_stream_rw_each()
{
    printf("-----test_stream_rw_each-----\n");
    int sv[2]; // To store the two socket descriptors
    char buf[100];

    // Create a socket pair using AF_UNIX address family and SOCK_STREAM type
    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) == -1)
    {
        perror("socketpair failed");
        exit(EXIT_FAILURE);
    }

    // Write data to the second socket (sv[0]) and read from the first socket (sv[1])
    const char *msg1 = "Message from sv[0] to sv[1]";
    if (write(sv[0], msg1, strlen(msg1)) == -1)
    {
        perror("write to sv[0] failed");
        exit(EXIT_FAILURE);
    }

    ssize_t len = read(sv[1], buf, sizeof(buf) - 1);
    if (len == -1)
    {
        perror("read from sv[1] failed");
        exit(EXIT_FAILURE);
    }
    buf[len] = '\0'; // Ensure the buffer is null-terminated
    printf("Received on sv[1]: %s\n", buf);

    // Write data to the first socket (sv[1]) and read from the second socket (sv[0])
    const char *msg2 = "Message from sv[1] to sv[0]";
    if (write(sv[1], msg2, strlen(msg2)) == -1)
    {
        perror("write to sv[1] failed");
        exit(EXIT_FAILURE);
    }

    len = read(sv[0], buf, sizeof(buf) - 1);
    if (len == -1)
    {
        perror("read from sv[0] failed");
        exit(EXIT_FAILURE);
    }
    buf[len] = '\0'; // Ensure the buffer is null-terminated
    printf("Received on sv[0]: %s\n", buf);

    // Close the sockets
    close(sv[0]);
    close(sv[1]);
}

// Test if two datagram sockets can read and write to each other
void test_dgram_rw_each()
{
    printf("-----test_dgram_rw_each-----\n");
    int sv[2]; // To store the two socket descriptors
    char buf[100];

    // Create a socket pair using AF_UNIX address family and SOCK_DGRAM type
    if (socketpair(AF_UNIX, SOCK_DGRAM, 0, sv) == -1)
    {
        perror("socketpair failed");
        exit(EXIT_FAILURE);
    }

    // Write data to the second socket (sv[0]) and read from the first socket (sv[1])
    const char *msg1 = "Message from sv[0] to sv[1]";
    if (write(sv[0], msg1, strlen(msg1)) == -1)
    {
        perror("write to sv[0] failed");
        exit(EXIT_FAILURE);
    }

    ssize_t len = read(sv[1], buf, sizeof(buf) - 1);
    if (len == -1)
    {
        perror("read from sv[1] failed");
        exit(EXIT_FAILURE);
    }
    buf[len] = '\0'; // Ensure the buffer is null-terminated
    printf("Received on sv[1]: %s\n", buf);

    // Write data to the first socket (sv[1]) and read from the second socket (sv[0])
    const char *msg2 = "Message from sv[1] to sv[0]";
    if (write(sv[1], msg2, strlen(msg2)) == -1)
    {
        perror("write to sv[1] failed");
        exit(EXIT_FAILURE);
    }

    len = read(sv[0], buf, sizeof(buf) - 1);
    if (len == -1)
    {
        perror("read from sv[0] failed");
        exit(EXIT_FAILURE);
    }
    buf[len] = '\0'; // Ensure the buffer is null-terminated
    printf("Received on sv[0]: %s\n", buf);

    // Close the sockets
    close(sv[0]);
    close(sv[1]);
}

/// @brief Test if the stream socket works correctly, meaning multiple writes can be read at once
void test_socketpair_stream()
{
    printf("-----test_socketpair_stream-----\n");
    int sv[2];
    char buf[1024];

    // Create a SOCK_STREAM socket pair
    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) == -1)
    {
        perror("socketpair failed");
        exit(EXIT_FAILURE);
    }

    printf("Testing SOCK_STREAM...\n");

    // Test unbounded stream transfer: write multiple pieces of data and read them in one go
    const char *part1 = "Hello, ";
    const char *part2 = "this is ";
    const char *part3 = "a message.";
    if (write(sv[0], part1, strlen(part1)) == -1 || write(sv[0], part2, strlen(part2)) == -1 ||
        write(sv[0], part3, strlen(part3)) == -1)
    {
        perror("write failed");
        exit(EXIT_FAILURE);
    }

    // Read all data at once
    ssize_t len = read(sv[1], buf, sizeof(buf) - 1);
    if (len == -1)
    {
        perror("read failed");
        exit(EXIT_FAILURE);
    }
    buf[len] = '\0';
    printf("Received (stream): %s\n", buf);

    // Close the sockets
    close(sv[0]);
    close(sv[1]);
}

/// @brief Test if the datagram socket works correctly, meaning multiple writes must be read in segments
void test_socketpair_dgram()
{
    printf("-----test_socketpair_dgram-----\n");
    int sv[2];
    char buf[1024];

    // Create a SOCK_DGRAM socket pair
    if (socketpair(AF_UNIX, SOCK_DGRAM, 0, sv) == -1)
    {
        perror("socketpair failed");
        exit(EXIT_FAILURE);
    }

    printf("Testing SOCK_DGRAM...\n");

    // Test bounded stream transfer: write multiple pieces of data, and due to the nature of DGRAM, it requires reading in parts
    const char *part1 = "Hello, ";
    const char *part2 = "this is ";
    const char *part3 = "a message.";
    if (write(sv[0], part1, strlen(part1)) == -1 || write(sv[0], part2, strlen(part2)) == -1 ||
        write(sv[0], part3, strlen(part3)) == -1)
    {
        perror("write failed");
        exit(EXIT_FAILURE);
    }

    // Read in segments until there is no more data
    ssize_t len;
    ssize_t total_len = 0;

    printf("Reading from SOCK_DGRAM socket:\n");

    // Limit the number of reads to prevent an infinite loop
    for (int i = 0; i < 3; i++)
    {
        len = read(sv[1], buf + total_len, sizeof(buf) - total_len - 1);

        if (len == -1)
        {
            perror("read failed");
            exit(EXIT_FAILURE);
        }

        if (len == 0)
        {
            // No more data to read, exit the loop
            printf("No more data to read.\n");
            break;
        }

        total_len += len;
        buf[total_len] = '\0'; // Ensure the string is properly terminated
        printf("Received (dgram part): %s\n", buf + total_len - len);
    }

    // Output the complete received message
    printf("Received complete message (dgram): %s\n", buf);

    // Close the sockets
    close(sv[0]);
    close(sv[1]);
}

int main(int argc, char **argv, char **envp)
{
    test_dgram_rw_each();
    test_stream_rw_each();
    test_socketpair_dgram();
    test_socketpair_stream();
    return 0;
}
```

If `sys_socketpair` sucessfully works, this program should output: 
```
-----test_stream_rw_each-----
Received on sv[1]: Message from sv[0] to sv[1]
Received on sv[0]: Message from sv[1] to sv[0]
-----test_socketpair_stream-----
Testing SOCK_STREAM...
Received (stream): Hello, this is a message.
-----test_dgram_rw_each-----
Received on sv[1]: Message from sv[0] to sv[1]
Received on sv[0]: Message from sv[1] to sv[0]
-----test_socketpair_dgram-----
Testing SOCK_DGRAM...
Reading from SOCK_DGRAM socket:
Received (dgram part): Hello, 
Received (dgram part): this is 
Received (dgram part): a message.
Received complete message (dgram): Hello, this is a message.
```