### PR TITLE
refactor: Extract RingBuffer from PipeRingBuffer for better reusability

### DIFF
--- a/api/ruxos_posix_api/src/imp/net.rs
+++ b/api/ruxos_posix_api/src/imp/net.rs
@@ -852,7 +852,8 @@ pub fn sys_getsockopt(
                     | ctypes::SO_RCVTIMEO
                     | ctypes::SO_REUSEADDR
                     | ctypes::SO_SNDBUF
-                    | ctypes::SO_SNDTIMEO => 0,
+                    | ctypes::SO_SNDTIMEO
+                    | ctypes::SO_BINDTODEVICE => 0,
                     _ => return Err(LinuxError::ENOPROTOOPT),
                 };
 

--- a/api/ruxos_posix_api/src/imp/stat.rs
+++ b/api/ruxos_posix_api/src/imp/stat.rs
@@ -61,3 +61,11 @@ pub fn sys_setpgid(pid: pid_t, pgid: pid_t) -> c_int {
     debug!("sys_setpgid: pid {}, pgid {} ", pid, pgid);
     syscall_body!(sys_setpgid, Ok(0))
 }
+
+/// set process sid (empty implementation)
+///
+/// TODO:
+pub fn sys_setsid() -> c_int {
+    warn!("sys_setsid: do nothing",);
+    syscall_body!(sys_setsid, Ok(0))
+}

--- a/api/ruxos_posix_api/src/lib.rs
+++ b/api/ruxos_posix_api/src/lib.rs
@@ -52,7 +52,7 @@ pub use imp::prctl::{sys_arch_prctl, sys_prctl};
 pub use imp::resources::{sys_getrlimit, sys_prlimit64, sys_setrlimit};
 pub use imp::stat::{
     sys_getegid, sys_geteuid, sys_getgid, sys_getpgid, sys_getuid, sys_setgid, sys_setpgid,
-    sys_setuid, sys_umask,
+    sys_setsid, sys_setuid, sys_umask,
 };
 pub use imp::sys::{sys_sysinfo, sys_uname};
 pub use imp::sys_invalid;

--- a/modules/ruxfs/src/mounts.rs
+++ b/modules/ruxfs/src/mounts.rs
@@ -101,7 +101,11 @@ pub(crate) fn etcfs() -> VfsResult<Arc<fs::ramfs::RamFileSystem>> {
     etc_root.create("passwd", VfsNodeType::File)?;
     let file_passwd = etc_root.clone().lookup("passwd")?;
     // format: username:password:uid:gid:allname:homedir:shell
-    file_passwd.write_at(0, b"root:x:0:0:root:/root:/bin/bash\n")?;
+    file_passwd.write_at(
+        0,
+        b"root:x:0:0:root:/root:/bin/busybox\n\
+        syswonder:x:1000:1000:root:/root:/bin/busybox\n",
+    )?;
 
     // Create /etc/group
     etc_root.create("group", VfsNodeType::File)?;
@@ -124,6 +128,10 @@ pub(crate) fn etcfs() -> VfsResult<Arc<fs::ramfs::RamFileSystem>> {
         ff02::2 ip6-allrouters \n\
         ff02::3 ip6-allhosts\n",
     )?;
+
+    etc_root.create("services", VfsNodeType::File)?;
+    let file_services = etc_root.clone().lookup("services")?;
+    file_services.write_at(0, b"ssh		22/tcp")?;
 
     // Create /etc/resolv.conf
     etc_root.create("resolv.conf", VfsNodeType::File)?;

--- a/ulib/ruxmusl/src/aarch64/mod.rs
+++ b/ulib/ruxmusl/src/aarch64/mod.rs
@@ -220,6 +220,8 @@ pub fn syscall(syscall_id: SyscallId, args: [usize; 6]) -> isize {
                 args[0] as *const ctypes::timespec,
                 args[1] as *mut ctypes::timespec,
             ) as _,
+            #[cfg(feature = "signal")]
+            SyscallId::SETITIMER => ruxos_posix_api::sys_setitimer(args[0] as _, args[1] as _) as _,
             SyscallId::CLOCK_SETTIME => ruxos_posix_api::sys_clock_settime(
                 args[0] as ctypes::clockid_t,
                 args[1] as *const ctypes::timespec,
@@ -269,6 +271,7 @@ pub fn syscall(syscall_id: SyscallId, args: [usize; 6]) -> isize {
                 ruxos_posix_api::sys_setpgid(args[0] as pid_t, args[1] as pid_t) as _
             }
             SyscallId::GETPGID => ruxos_posix_api::sys_getpgid(args[0] as pid_t) as _,
+            SyscallId::SETSID => ruxos_posix_api::sys_setsid() as _,
             SyscallId::UNAME => ruxos_posix_api::sys_uname(args[0] as *mut core::ffi::c_void) as _,
             SyscallId::GETRLIMIT => {
                 ruxos_posix_api::sys_getrlimit(args[0] as c_int, args[1] as *mut ctypes::rlimit)

--- a/ulib/ruxmusl/src/aarch64/syscall_id.rs
+++ b/ulib/ruxmusl/src/aarch64/syscall_id.rs
@@ -80,6 +80,8 @@ pub enum SyscallId {
     #[cfg(feature = "multitask")]
     FUTEX = 98,
     NANO_SLEEP = 101,
+    #[cfg(feature = "signal")]
+    SETITIMER = 103,
     CLOCK_SETTIME = 112,
     CLOCK_GETTIME = 113,
     CLOCK_GETRES = 114,
@@ -100,6 +102,7 @@ pub enum SyscallId {
     TIMES = 153,
     SETPGID = 154,
     GETPGID = 155,
+    SETSID = 157,
     UNAME = 160,
     GETRLIMIT = 163,
     SETRLIMIT = 164,


### PR DESCRIPTION
Motivation:
The RingBuffer is a generic data structure that can be useful in multiple contexts. By extracting it from PipeRingBuffer, we avoid code duplication and make it easier to maintain and test.

Impact:

Existing PipeRingBuffer functionality remains unchanged
New modules can now import and use RingBuffer directly

Add some unit tests for RingBuffer