### PR TITLE
Implement: implement the syscall `ftruncate` and fix the related file mapping problem.

### DIFF
--- a/api/ruxos_posix_api/src/imp/fs.rs
+++ b/api/ruxos_posix_api/src/imp/fs.rs
@@ -118,6 +118,16 @@ pub fn sys_lseek(fd: c_int, offset: ctypes::off_t, whence: c_int) -> ctypes::off
     })
 }
 
+/// Truncate a file to a specified length.
+pub unsafe fn sys_ftruncate(fd: c_int, length: ctypes::off_t) -> c_int {
+    syscall_body!(sys_ftruncate, {
+        debug!("sys_ftruncate <= {} {}", fd, length);
+        let file = file_from_fd(fd)?;
+        file.truncate(length as u64)?;
+        Ok(0)
+    })
+}
+
 /// Synchronize a file's in-core state with storage device
 ///
 /// TODO

--- a/api/ruxos_posix_api/src/imp/mmap/api.rs
+++ b/api/ruxos_posix_api/src/imp/mmap/api.rs
@@ -19,8 +19,8 @@ use ruxhal::mem::VirtAddr;
 use ruxmm::paging::pte_update_page;
 
 use super::utils::{
-    find_free_region, get_mflags_from_usize, get_overlap, release_pages_mapped, shift_mapped_page,
-    snatch_fixed_region, VMA_END,
+    find_free_region, get_mflags_from_usize, get_overlap, release_pages_mapped,
+    release_pages_mapped_without_wb, shift_mapped_page, snatch_fixed_region, VMA_END,
 };
 use ruxtask::current;
 use ruxtask::vma::Vma;
@@ -50,7 +50,7 @@ pub fn sys_mmap(
     syscall_body!(sys_mmap, {
         // transform C-type into rust-type
         let start = start as usize;
-        let len = VirtAddr::from(len).align_up_4k().as_usize();
+        let mapping_len = VirtAddr::from(len).align_up_4k().as_usize();
         if !VirtAddr::from(start).is_aligned(PAGE_SIZE_4K) || len == 0 {
             error!(
                 "mmap failed because start:0x{:x} is not aligned or len:0x{:x} == 0",
@@ -85,15 +85,16 @@ pub fn sys_mmap(
         let addr_condition = if start == 0 { None } else { Some(start) };
 
         let try_addr = if flags & ctypes::MAP_FIXED != 0 {
-            snatch_fixed_region(&mut vma_map, start, len)
+            snatch_fixed_region(&mut vma_map, start, mapping_len)
         } else {
-            find_free_region(&vma_map, addr_condition, len)
+            find_free_region(&vma_map, addr_condition, mapping_len)
         };
 
         match try_addr {
             Some(vaddr) => {
                 new.start_addr = vaddr;
-                new.end_addr = vaddr + len;
+                new.end_addr = vaddr + mapping_len;
+                new.size = len;
                 vma_map.insert(vaddr, new);
                 Ok(vaddr as *mut c_void)
             }
@@ -449,14 +450,15 @@ pub fn sys_mremap(
                     Vma::clone_from(&old_vma, old_end, old_vma.end_addr),
                 );
             }
-            old_vma.end_addr = new_end;
+            old_vma.end_addr = VirtAddr::from(new_end).align_up_4k().as_usize();
+            old_vma.size = new_size;
+            vma_map.insert(old_vma.start_addr, old_vma);
 
-            // delete the mapped and swapped page outside of new vma.
-            release_pages_mapped(new_end, old_end);
+            // for the shrink region, it should be removed without write-back
+            release_pages_mapped_without_wb(new_end, old_end);
             #[cfg(feature = "fs")]
             release_pages_swaped(new_end, old_end);
 
-            // vma_map.insert(old_vma.start_addr, old_vma);
             return Ok(ret as *mut c_void);
         }
         // expanding the original address does not require changing the mapped page.

--- a/api/ruxos_posix_api/src/imp/mmap/trap.rs
+++ b/api/ruxos_posix_api/src/imp/mmap/trap.rs
@@ -44,8 +44,9 @@ impl ruxhal::trap::TrapHandler for TrapHandlerImpl {
         let mut binding_mem_map = binding_task.mm.vma_map.lock();
         let vma_map = binding_mem_map.deref_mut();
         if let Some(vma) = vma_map.upper_bound(Bound::Included(&vaddr)).value() {
+            let vma_end_aligned = vma.end_addr;
             // Check if page existing in the vma, go to panic if not.
-            if vma.end_addr <= vaddr {
+            if vma_end_aligned <= vaddr {
                 error!(
                     "Page Fault not match: vaddr=0x{:x?}, cause={:?}",
                     vaddr, cause
@@ -163,7 +164,7 @@ impl ruxhal::trap::TrapHandler for TrapHandlerImpl {
                     && (vma.flags & ctypes::MAP_PRIVATE == 0)
                     && (vma.file.is_some())
                 {
-                    let map_length = min(PAGE_SIZE_4K, vma.end_addr - vaddr);
+                    let map_length = min(PAGE_SIZE_4K, vma.start_addr + vma.size - vaddr);
                     let offset = vma.offset + (vaddr - vma.start_addr);
                     let file_info = FileInfo {
                         file: vma.file.as_ref().unwrap().clone(),

--- a/api/ruxos_posix_api/src/lib.rs
+++ b/api/ruxos_posix_api/src/lib.rs
@@ -70,10 +70,10 @@ pub use imp::fd_ops::sys_dup3;
 pub use imp::fd_ops::{sys_close, sys_dup, sys_dup2, sys_fcntl};
 #[cfg(feature = "fs")]
 pub use imp::fs::{
-    sys_chdir, sys_faccessat, sys_fchownat, sys_fdatasync, sys_fstat, sys_fsync, sys_getcwd,
-    sys_getdents64, sys_lseek, sys_lstat, sys_mkdir, sys_mkdirat, sys_newfstatat, sys_open,
-    sys_openat, sys_pread64, sys_preadv, sys_pwrite64, sys_readlinkat, sys_rename, sys_renameat,
-    sys_rmdir, sys_stat, sys_unlink, sys_unlinkat,
+    sys_chdir, sys_faccessat, sys_fchownat, sys_fdatasync, sys_fstat, sys_fsync, sys_ftruncate,
+    sys_getcwd, sys_getdents64, sys_lseek, sys_lstat, sys_mkdir, sys_mkdirat, sys_newfstatat,
+    sys_open, sys_openat, sys_pread64, sys_preadv, sys_pwrite64, sys_readlinkat, sys_rename,
+    sys_renameat, sys_rmdir, sys_stat, sys_unlink, sys_unlinkat,
 };
 #[cfg(feature = "epoll")]
 pub use imp::io_mpx::{sys_epoll_create1, sys_epoll_ctl, sys_epoll_pwait, sys_epoll_wait};

--- a/modules/ruxtask/src/vma.rs
+++ b/modules/ruxtask/src/vma.rs
@@ -146,6 +146,8 @@ pub struct Vma {
     pub start_addr: usize,
     /// end address of the mapping
     pub end_addr: usize,
+    /// mmap size of the mapping
+    pub size: usize,
     /// file that the mapping is backed by
     pub file: Option<Arc<File>>,
     /// offset in the file
@@ -188,6 +190,7 @@ impl Vma {
         Vma {
             start_addr: 0,
             end_addr: 0,
+            size: 0,
             // #[cfg(feature = "fs")]
             file,
             offset,
@@ -202,6 +205,7 @@ impl Vma {
         Vma {
             start_addr,
             end_addr,
+            size: vma.size,
             // #[cfg(feature = "fs")]
             file: vma.file.clone(),
             offset: vma.offset,

--- a/ulib/ruxmusl/src/aarch64/mod.rs
+++ b/ulib/ruxmusl/src/aarch64/mod.rs
@@ -74,6 +74,10 @@ pub fn syscall(syscall_id: SyscallId, args: [usize; 6]) -> isize {
                 args[3] as *const core::ffi::c_char,
             ) as _,
             #[cfg(feature = "fs")]
+            SyscallId::FTRUNCATE => {
+                ruxos_posix_api::sys_ftruncate(args[0] as c_int, args[1] as ctypes::off_t) as _
+            }
+            #[cfg(feature = "fs")]
             SyscallId::FACCESSAT => ruxos_posix_api::sys_faccessat(
                 args[0] as c_int,
                 args[1] as *const c_char,

--- a/ulib/ruxmusl/src/aarch64/syscall_id.rs
+++ b/ulib/ruxmusl/src/aarch64/syscall_id.rs
@@ -30,6 +30,8 @@ pub enum SyscallId {
     #[cfg(feature = "fs")]
     RENAMEAT = 38,
     #[cfg(feature = "fs")]
+    FTRUNCATE = 46,
+    #[cfg(feature = "fs")]
     FACCESSAT = 48,
     #[cfg(feature = "fs")]
     CHDIR = 49,


### PR DESCRIPTION
When mmap is used for file mapping, write-back operations are performed on a per-page basis, which may change the size of the file.