### PR TITLE
feat(vfs): store file mode and add fchmodat syscalls

### DIFF
--- a/api/ruxos_posix_api/src/imp/stat.rs
+++ b/api/ruxos_posix_api/src/imp/stat.rs
@@ -11,11 +11,17 @@ use crate::ctypes::{self, gid_t, pid_t, uid_t};
 use core::ffi::c_int;
 
 /// Set file mode creation mask
-///
-/// TODO:
 pub fn sys_umask(mode: ctypes::mode_t) -> ctypes::mode_t {
-    debug!("sys_umask <= mode: {:x}", mode);
-    syscall_body!(sys_umask, Ok(0))
+    debug!("sys_umask <= mode: {:#o}", mode);
+
+    syscall_body!(sys_umask, {
+        #[cfg(feature = "fd")]
+        {
+            Ok(ruxtask::fs::replace_umask(mode as _))
+        }
+        #[cfg(not(feature = "fd"))]
+        Ok(0)
+    })
 }
 
 /// Returns the effective user ID of the calling process

--- a/api/ruxos_posix_api/src/lib.rs
+++ b/api/ruxos_posix_api/src/lib.rs
@@ -70,10 +70,10 @@ pub use imp::fd_ops::sys_dup3;
 pub use imp::fd_ops::{sys_close, sys_dup, sys_dup2, sys_fcntl};
 #[cfg(feature = "fs")]
 pub use imp::fs::{
-    sys_chdir, sys_faccessat, sys_fchownat, sys_fdatasync, sys_fstat, sys_fsync, sys_ftruncate,
-    sys_getcwd, sys_getdents64, sys_lseek, sys_lstat, sys_mkdir, sys_mkdirat, sys_mknodat,
-    sys_newfstatat, sys_open, sys_openat, sys_pread64, sys_preadv, sys_pwrite64, sys_readlinkat,
-    sys_rename, sys_renameat, sys_rmdir, sys_stat, sys_unlink, sys_unlinkat,
+    sys_chdir, sys_faccessat, sys_fchmodat, sys_fchownat, sys_fdatasync, sys_fstat, sys_fsync,
+    sys_ftruncate, sys_getcwd, sys_getdents64, sys_lseek, sys_lstat, sys_mkdir, sys_mkdirat,
+    sys_mknodat, sys_newfstatat, sys_open, sys_openat, sys_pread64, sys_preadv, sys_pwrite64,
+    sys_readlinkat, sys_rename, sys_renameat, sys_rmdir, sys_stat, sys_unlink, sys_unlinkat,
 };
 #[cfg(feature = "epoll")]
 pub use imp::io_mpx::{sys_epoll_create1, sys_epoll_ctl, sys_epoll_pwait, sys_epoll_wait};

--- a/crates/axfs_devfs/src/lib.rs
+++ b/crates/axfs_devfs/src/lib.rs
@@ -31,7 +31,7 @@ pub use self::random::RandomDev;
 pub use self::zero::ZeroDev;
 
 use alloc::sync::Arc;
-use axfs_vfs::{AbsPath, VfsNodeRef, VfsOps, VfsResult};
+use axfs_vfs::{AbsPath, VfsNodePerm, VfsNodeRef, VfsOps, VfsResult};
 use core::sync::atomic::AtomicU64;
 use spin::once::Once;
 
@@ -68,14 +68,14 @@ impl DeviceFileSystem {
         let ialloc = Arc::new(InoAllocator::new(10));
         Self {
             parent: Once::new(),
-            root: DirNode::new(2, None, Arc::downgrade(&ialloc)),
+            root: DirNode::new(2, VfsNodePerm::default_dir(), None, Arc::downgrade(&ialloc)),
             _ialloc: ialloc,
         }
     }
 
     /// Create a subdirectory at the root directory.
-    pub fn mkdir(&self, name: &'static str) -> Arc<DirNode> {
-        self.root.mkdir(name)
+    pub fn mkdir(&self, name: &'static str, mode: VfsNodePerm) -> Arc<DirNode> {
+        self.root.mkdir(name, mode)
     }
 
     /// Add a node to the root directory.

--- a/crates/axfs_devfs/src/null.rs
+++ b/crates/axfs_devfs/src/null.rs
@@ -24,7 +24,9 @@ impl VfsNodeOps for NullDev {
             0,
         ))
     }
-
+    fn set_mode(&self, _mode: VfsNodePerm) -> VfsResult {
+        Ok(())
+    }
     fn read_at(&self, _offset: u64, _buf: &mut [u8]) -> VfsResult<usize> {
         Ok(0)
     }

--- a/crates/axfs_devfs/src/pts/master.rs
+++ b/crates/axfs_devfs/src/pts/master.rs
@@ -77,6 +77,10 @@ impl VfsNodeOps for PtyMaster {
         ))
     }
 
+    fn set_mode(&self, _mode: VfsNodePerm) -> VfsResult {
+        Ok(())
+    }
+
     fn release(&self) -> VfsResult {
         self.ptmx.ptsfs().remove_pty(self.idx);
         Ok(())

--- a/crates/axfs_devfs/src/pts/ptmx.rs
+++ b/crates/axfs_devfs/src/pts/ptmx.rs
@@ -44,5 +44,9 @@ impl VfsNodeOps for Ptmx {
         ))
     }
 
+    fn set_mode(&self, _mode: VfsNodePerm) -> VfsResult {
+        Ok(())
+    }
+
     impl_vfs_non_dir_default!();
 }

--- a/crates/axfs_devfs/src/pts/root.rs
+++ b/crates/axfs_devfs/src/pts/root.rs
@@ -72,6 +72,10 @@ impl VfsNodeOps for PtsRootInode {
         ))
     }
 
+    fn set_mode(&self, _mode: VfsNodePerm) -> VfsResult {
+        Ok(())
+    }
+
     fn parent(&self) -> Option<VfsNodeRef> {
         self.parent.get().unwrap().upgrade()
     }
@@ -123,7 +127,7 @@ impl VfsNodeOps for PtsRootInode {
         Ok(dirents.len())
     }
 
-    fn create(&self, _path: &RelPath, _ty: axfs_vfs::VfsNodeType) -> VfsResult {
+    fn create(&self, _path: &RelPath, _ty: axfs_vfs::VfsNodeType, _mode: VfsNodePerm) -> VfsResult {
         ax_err!(PermissionDenied)
     }
 

--- a/crates/axfs_devfs/src/pts/slave.rs
+++ b/crates/axfs_devfs/src/pts/slave.rs
@@ -49,6 +49,10 @@ impl VfsNodeOps for PtySlaveInode {
         ))
     }
 
+    fn set_mode(&self, _mode: VfsNodePerm) -> VfsResult {
+        Ok(())
+    }
+
     fn read_at(&self, offset: u64, buf: &mut [u8]) -> VfsResult<usize> {
         self.slave.read_at(offset, buf)
     }
@@ -98,6 +102,10 @@ impl VfsNodeOps for PtySlave {
             0,
             0,
         ))
+    }
+
+    fn set_mode(&self, _mode: VfsNodePerm) -> VfsResult {
+        Ok(())
     }
 
     fn read_at(&self, _offset: u64, dst: &mut [u8]) -> VfsResult<usize> {

--- a/crates/axfs_devfs/src/random.rs
+++ b/crates/axfs_devfs/src/random.rs
@@ -38,6 +38,10 @@ impl VfsNodeOps for RandomDev {
         ))
     }
 
+    fn set_mode(&self, _mode: VfsNodePerm) -> VfsResult {
+        Ok(())
+    }
+
     fn read_at(&self, _offset: u64, buf: &mut [u8]) -> VfsResult<usize> {
         let len = buf.len() >> 2;
         let remainder = buf.len() & 0x3;

--- a/crates/axfs_devfs/src/tests.rs
+++ b/crates/axfs_devfs/src/tests.rs
@@ -144,9 +144,9 @@ fn test_devfs() {
     devfs.add("null", Arc::new(NullDev));
     devfs.add("zero", Arc::new(ZeroDev));
 
-    let dir_foo = devfs.mkdir("foo");
+    let dir_foo = devfs.mkdir("foo", VfsNodePerm::default_dir());
     dir_foo.add("f2", Arc::new(ZeroDev));
-    let dir_bar = dir_foo.mkdir("bar");
+    let dir_bar = dir_foo.mkdir("bar", VfsNodePerm::default_dir());
     dir_bar.add("f1", Arc::new(NullDev));
 
     test_devfs_ops(&devfs).unwrap();

--- a/crates/axfs_devfs/src/zero.rs
+++ b/crates/axfs_devfs/src/zero.rs
@@ -25,6 +25,10 @@ impl VfsNodeOps for ZeroDev {
         ))
     }
 
+    fn set_mode(&self, _mode: VfsNodePerm) -> VfsResult {
+        Ok(())
+    }
+
     fn read_at(&self, _offset: u64, buf: &mut [u8]) -> VfsResult<usize> {
         buf.fill(0);
         Ok(buf.len())

--- a/crates/axfs_ramfs/src/file.rs
+++ b/crates/axfs_ramfs/src/file.rs
@@ -8,7 +8,9 @@
  */
 
 use alloc::vec::Vec;
-use axfs_vfs::{impl_vfs_non_dir_default, VfsNodeAttr, VfsNodeOps, VfsResult};
+use axfs_vfs::{
+    impl_vfs_non_dir_default, VfsNodeAttr, VfsNodeOps, VfsNodePerm, VfsNodeType, VfsResult,
+};
 use spin::rwlock::RwLock;
 
 /// The file node in the RAM filesystem.
@@ -16,13 +18,15 @@ use spin::rwlock::RwLock;
 /// It implements [`axfs_vfs::VfsNodeOps`].
 pub struct FileNode {
     ino: u64,
+    mode: RwLock<VfsNodePerm>,
     content: RwLock<Vec<u8>>,
 }
 
 impl FileNode {
-    pub(super) const fn new(ino: u64) -> Self {
+    pub(super) const fn new(ino: u64, mode: VfsNodePerm) -> Self {
         Self {
             ino,
+            mode: RwLock::new(mode),
             content: RwLock::new(Vec::new()),
         }
     }
@@ -30,11 +34,18 @@ impl FileNode {
 
 impl VfsNodeOps for FileNode {
     fn get_attr(&self) -> VfsResult<VfsNodeAttr> {
-        Ok(VfsNodeAttr::new_file(
+        Ok(VfsNodeAttr::new(
             self.ino,
+            *self.mode.read(),
+            VfsNodeType::File,
             self.content.read().len() as _,
             0,
         ))
+    }
+
+    fn set_mode(&self, mode: VfsNodePerm) -> VfsResult {
+        *self.mode.write() = mode;
+        Ok(())
     }
 
     fn truncate(&self, size: u64) -> VfsResult {

--- a/crates/axfs_ramfs/src/lib.rs
+++ b/crates/axfs_ramfs/src/lib.rs
@@ -25,7 +25,7 @@ pub use self::dir::DirNode;
 pub use self::file::FileNode;
 
 use alloc::sync::Arc;
-use axfs_vfs::{AbsPath, VfsNodeRef, VfsOps, VfsResult};
+use axfs_vfs::{AbsPath, VfsNodePerm, VfsNodeRef, VfsOps, VfsResult};
 use core::sync::atomic::AtomicU64;
 use spin::once::Once;
 
@@ -62,7 +62,12 @@ impl RamFileSystem {
         let ialloc = Arc::new(InoAllocator::new(0));
         Self {
             parent: Once::new(),
-            root: DirNode::new(ialloc.alloc(), None, Arc::downgrade(&ialloc)),
+            root: DirNode::new(
+                ialloc.alloc(),
+                VfsNodePerm::default_dir(),
+                None,
+                Arc::downgrade(&ialloc),
+            ),
             _ialloc: ialloc,
         }
     }

--- a/crates/axfs_ramfs/src/tests.rs
+++ b/crates/axfs_ramfs/src/tests.rs
@@ -9,7 +9,7 @@
 
 use std::sync::Arc;
 
-use axfs_vfs::{RelPath, VfsError, VfsNodeType, VfsResult};
+use axfs_vfs::{RelPath, VfsError, VfsNodePerm, VfsNodeType, VfsResult};
 
 use crate::*;
 
@@ -137,24 +137,48 @@ fn test_ramfs() {
 
     let ramfs = RamFileSystem::new();
     let root = ramfs.root_dir();
-    root.create(&RelPath::new_canonicalized("f1"), VfsNodeType::File)
-        .unwrap();
-    root.create(&RelPath::new_canonicalized("f2"), VfsNodeType::File)
-        .unwrap();
-    root.create(&RelPath::new_canonicalized("foo"), VfsNodeType::Dir)
-        .unwrap();
+    root.create(
+        &RelPath::new_canonicalized("f1"),
+        VfsNodeType::File,
+        VfsNodePerm::default_file(),
+    )
+    .unwrap();
+    root.create(
+        &RelPath::new_canonicalized("f2"),
+        VfsNodeType::File,
+        VfsNodePerm::default_file(),
+    )
+    .unwrap();
+    root.create(
+        &RelPath::new_canonicalized("foo"),
+        VfsNodeType::Dir,
+        VfsNodePerm::default_file(),
+    )
+    .unwrap();
 
     let dir_foo = root.lookup(&RelPath::new_canonicalized("foo")).unwrap();
     dir_foo
-        .create(&RelPath::new_canonicalized("f3"), VfsNodeType::File)
+        .create(
+            &RelPath::new_canonicalized("f3"),
+            VfsNodeType::File,
+            VfsNodePerm::default_file(),
+        )
         .unwrap();
     dir_foo
-        .create(&RelPath::new_canonicalized("bar"), VfsNodeType::Dir)
+        .create(
+            &RelPath::new_canonicalized("bar"),
+            VfsNodeType::Dir,
+            VfsNodePerm::default_dir(),
+        )
         .unwrap();
 
     let dir_bar = dir_foo.lookup(&RelPath::new_canonicalized("bar")).unwrap();
     dir_bar
-        .create(&RelPath::new_canonicalized("f4"), VfsNodeType::File)
+        .create(
+            &RelPath::new_canonicalized("f4"),
+            VfsNodeType::File,
+            VfsNodePerm::default_file(),
+        )
         .unwrap();
 
     let mut entries = ramfs.root_dir_node().get_entries();

--- a/crates/axfs_vfs/src/macros.rs
+++ b/crates/axfs_vfs/src/macros.rs
@@ -58,7 +58,12 @@ macro_rules! impl_vfs_non_dir_default {
             $crate::__priv::ax_err!(NotADirectory)
         }
 
-        fn create(&self, _path: &$crate::RelPath, _ty: $crate::VfsNodeType) -> $crate::VfsResult {
+        fn create(
+            &self,
+            _path: &$crate::RelPath,
+            _ty: $crate::VfsNodeType,
+            _mode: $crate::VfsNodePerm,
+        ) -> $crate::VfsResult {
             $crate::__priv::ax_err!(NotADirectory)
         }
 

--- a/crates/axfs_vfs/src/structs.rs
+++ b/crates/axfs_vfs/src/structs.rs
@@ -245,53 +245,6 @@ impl VfsNodeAttr {
         }
     }
 
-    /// Creates a new `VfsNodeAttr` for a file, with the default file permission.
-    pub const fn new_file(ino: u64, size: u64, blocks: u64) -> Self {
-        Self {
-            ino,
-            mode: VfsNodePerm::default_file(),
-            ty: VfsNodeType::File,
-            size,
-            blocks,
-        }
-    }
-
-    /// Creates a new `VfsNodeAttr` for a directory, with the default directory
-    /// permission.
-    pub const fn new_dir(ino: u64, size: u64, blocks: u64) -> Self {
-        Self {
-            ino,
-            mode: VfsNodePerm::default_dir(),
-            ty: VfsNodeType::Dir,
-            size,
-            blocks,
-        }
-    }
-
-    /// Creates a new `VfsNodeAttr` for a socket, with the default socket permission.
-    /// The size and blocks are set to 0.
-    pub const fn new_socket(ino: u64) -> Self {
-        Self {
-            ino,
-            mode: VfsNodePerm::default_socket(),
-            ty: VfsNodeType::Socket,
-            size: 0,
-            blocks: 0,
-        }
-    }
-
-    /// Creates a new `VfsNodeAttr` for a fifo file, with the default fifo permission.
-    /// The size and blocks are set to 0.
-    pub const fn new_fifo(ino: u64) -> Self {
-        Self {
-            ino,
-            mode: VfsNodePerm::default_fifo(),
-            ty: VfsNodeType::Fifo,
-            size: 0,
-            blocks: 0,
-        }
-    }
-
     /// Returns the inode number of the node.
     pub const fn ino(&self) -> u64 {
         self.ino

--- a/modules/rux9p/src/drv.rs
+++ b/modules/rux9p/src/drv.rs
@@ -915,6 +915,11 @@ impl FileAttr {
         self.mode
     }
 
+    pub fn set_perm(&mut self, perm: u32) {
+        self.vaild |= _9P_SETATTR_MODE;
+        self.mode = perm;
+    }
+
     pub fn set_size(&mut self, size: u64) {
         self.vaild |= _9P_SETATTR_SIZE;
         self.size = size;
@@ -1032,6 +1037,10 @@ impl UStatFs {
 
     pub fn get_perm(&self) -> u32 {
         self.mode
+    }
+
+    pub fn set_mode(&mut self, perm: u32) {
+        self.mode = perm;
     }
 
     pub fn get_ftype(&self) -> u8 {

--- a/modules/ruxfs/src/api/mod.rs
+++ b/modules/ruxfs/src/api/mod.rs
@@ -17,11 +17,11 @@ pub use super::{
 };
 use alloc::{string::String, vec::Vec};
 use axerrno::ax_err;
-use axfs_vfs::VfsError;
+use axfs_vfs::{VfsError, VfsNodePerm, VfsNodeType};
 use axio::{self as io, prelude::*, Error, Result};
 /// Opens a regular file at given path. Fails if path points to a directory.
 pub fn open_file(path: &AbsPath, flags: OpenFlags) -> Result<File> {
-    let node = fops::open_abspath(path, flags)?;
+    let node = fops::open_abspath(path, flags, VfsNodePerm::default_file())?;
     if node.get_attr()?.is_dir() {
         Err(Error::IsADirectory)
     } else {
@@ -31,7 +31,7 @@ pub fn open_file(path: &AbsPath, flags: OpenFlags) -> Result<File> {
 
 /// Opens a directory at given path. Fails if path points to non-directory.
 pub fn open_dir(path: &AbsPath, flags: OpenFlags) -> Result<Directory> {
-    let node = fops::open_abspath(path, flags)?;
+    let node = fops::open_abspath(path, flags, VfsNodePerm::default_dir())?;
     if node.get_attr()?.is_dir() {
         Ok(Directory::new(path.to_owned(), node, flags))
     } else {
@@ -93,7 +93,7 @@ pub fn create_dir(path: &AbsPath) -> io::Result<()> {
         Err(VfsError::NotFound) => {}
         Err(e) => return ax_err!(e),
     }
-    fops::create_dir(path)
+    fops::create(path, VfsNodeType::Dir, VfsNodePerm::default_dir())
 }
 
 /// Recursively create a directory and all of its parent components if they

--- a/modules/ruxfs/src/fs/fatfs.rs
+++ b/modules/ruxfs/src/fs/fatfs.rs
@@ -144,6 +144,10 @@ impl VfsNodeOps for DirWrapper<'static> {
         ))
     }
 
+    fn set_mode(&self, _mode: VfsNodePerm) -> VfsResult {
+        Ok(())
+    }
+
     fn parent(&self) -> Option<VfsNodeRef> {
         self.0
             .open_dir("..")
@@ -174,7 +178,7 @@ impl VfsNodeOps for DirWrapper<'static> {
         }
     }
 
-    fn create(&self, path: &RelPath, ty: VfsNodeType) -> VfsResult {
+    fn create(&self, path: &RelPath, ty: VfsNodeType, _mode: VfsNodePerm) -> VfsResult {
         debug!("create {:?} at fatfs: {}", ty, path);
         if path.is_empty() {
             return Ok(());

--- a/modules/ruxfs/src/mounts.rs
+++ b/modules/ruxfs/src/mounts.rs
@@ -37,44 +37,68 @@ pub(crate) fn ramfs() -> Arc<fs::ramfs::RamFileSystem> {
 
 #[cfg(feature = "procfs")]
 pub(crate) fn procfs() -> VfsResult<Arc<fs::ramfs::RamFileSystem>> {
+    use axfs_vfs::VfsNodePerm;
+
     let procfs = fs::ramfs::RamFileSystem::new();
     let proc_root = procfs.root_dir();
 
     #[cfg(feature = "alloc")]
     {
         // Create /proc/cpuinfo
-        proc_root.create(&RelPath::new("cpuinfo"), VfsNodeType::File)?;
+        proc_root.create(
+            &RelPath::new("cpuinfo"),
+            VfsNodeType::File,
+            VfsNodePerm::default_file(),
+        )?;
         let file_cpuinfo = proc_root.clone().lookup(&RelPath::new("cpuinfo"))?;
         file_cpuinfo.write_at(0, get_cpuinfo().as_bytes())?;
 
         // Create /proc/meminfo
-        proc_root.create(&RelPath::new("meminfo"), VfsNodeType::File)?;
+        proc_root.create(
+            &RelPath::new("meminfo"),
+            VfsNodeType::File,
+            VfsNodePerm::default_file(),
+        )?;
         let file_meminfo = proc_root.clone().lookup(&RelPath::new("meminfo"))?;
         file_meminfo.write_at(0, get_meminfo().as_bytes())?;
     }
 
     // Create /proc/sys/net/core/somaxconn
-    proc_root.create_recursive(&RelPath::new("sys/net/core/somaxconn"), VfsNodeType::File)?;
+    proc_root.create_recursive(
+        &RelPath::new("sys/net/core/somaxconn"),
+        VfsNodeType::File,
+        VfsNodePerm::default_file(),
+    )?;
     let file_somaxconn = proc_root
         .clone()
         .lookup(&RelPath::new("sys/net/core/somaxconn"))?;
     file_somaxconn.write_at(0, b"4096\n")?;
 
     // Create /proc/sys/vm/overcommit_memory
-    proc_root.create_recursive(&RelPath::new("sys/vm/overcommit_memory"), VfsNodeType::File)?;
+    proc_root.create_recursive(
+        &RelPath::new("sys/vm/overcommit_memory"),
+        VfsNodeType::File,
+        VfsNodePerm::default_file(),
+    )?;
     let file_over = proc_root
         .clone()
         .lookup(&RelPath::new("sys/vm/overcommit_memory"))?;
     file_over.write_at(0, b"0\n")?;
 
     // Create /proc/self/stat
-    proc_root.create_recursive(&RelPath::new("self/stat"), VfsNodeType::File)?;
+    proc_root.create_recursive(
+        &RelPath::new("self/stat"),
+        VfsNodeType::File,
+        VfsNodePerm::default_file(),
+    )?;
 
     Ok(Arc::new(procfs))
 }
 
 #[cfg(feature = "sysfs")]
 pub(crate) fn sysfs() -> VfsResult<Arc<fs::ramfs::RamFileSystem>> {
+    use axfs_vfs::VfsNodePerm;
+
     let sysfs = fs::ramfs::RamFileSystem::new();
     let sys_root = sysfs.root_dir();
 
@@ -84,6 +108,7 @@ pub(crate) fn sysfs() -> VfsResult<Arc<fs::ramfs::RamFileSystem>> {
     sys_root.create_recursive(
         &RelPath::new("kernel/mm/transparent_hugepage/enabled"),
         VfsNodeType::File,
+        VfsNodePerm::default_file(),
     )?;
     let file_hp = sys_root
         .clone()
@@ -94,6 +119,7 @@ pub(crate) fn sysfs() -> VfsResult<Arc<fs::ramfs::RamFileSystem>> {
     sys_root.create_recursive(
         &RelPath::new("devices/system/clocksource/clocksource0/current_clocksource"),
         VfsNodeType::File,
+        VfsNodePerm::default_file(),
     )?;
     let file_cc = sys_root.clone().lookup(&RelPath::new(
         "devices/system/clocksource/clocksource0/current_clocksource",
@@ -105,11 +131,17 @@ pub(crate) fn sysfs() -> VfsResult<Arc<fs::ramfs::RamFileSystem>> {
 
 #[cfg(feature = "etcfs")]
 pub(crate) fn etcfs() -> VfsResult<Arc<fs::ramfs::RamFileSystem>> {
+    use axfs_vfs::VfsNodePerm;
+
     let etcfs = fs::ramfs::RamFileSystem::new();
     let etc_root = etcfs.root_dir();
 
     // Create /etc/passwd, and /etc/hosts
-    etc_root.create(&RelPath::new("passwd"), VfsNodeType::File)?;
+    etc_root.create(
+        &RelPath::new("passwd"),
+        VfsNodeType::File,
+        VfsNodePerm::default_file(),
+    )?;
     let file_passwd = etc_root.clone().lookup(&RelPath::new("passwd"))?;
     // format: username:password:uid:gid:allname:homedir:shell
     file_passwd.write_at(
@@ -119,15 +151,27 @@ pub(crate) fn etcfs() -> VfsResult<Arc<fs::ramfs::RamFileSystem>> {
     )?;
 
     // Create /etc/group
-    etc_root.create(&RelPath::new("group"), VfsNodeType::File)?;
+    etc_root.create(
+        &RelPath::new("group"),
+        VfsNodeType::File,
+        VfsNodePerm::default_file(),
+    )?;
     let file_group = etc_root.clone().lookup(&RelPath::new("group"))?;
     file_group.write_at(0, b"root:x:0:\n")?;
 
     // Create /etc/localtime
-    etc_root.create(&RelPath::new("localtime"), VfsNodeType::File)?;
+    etc_root.create(
+        &RelPath::new("localtime"),
+        VfsNodeType::File,
+        VfsNodePerm::default_file(),
+    )?;
 
     // Create /etc/hosts
-    etc_root.create(&RelPath::new("hosts"), VfsNodeType::File)?;
+    etc_root.create(
+        &RelPath::new("hosts"),
+        VfsNodeType::File,
+        VfsNodePerm::default_file(),
+    )?;
     let file_hosts = etc_root.clone().lookup(&RelPath::new("hosts"))?;
     file_hosts.write_at(
         0,
@@ -140,12 +184,20 @@ pub(crate) fn etcfs() -> VfsResult<Arc<fs::ramfs::RamFileSystem>> {
         ff02::3 ip6-allhosts\n",
     )?;
 
-    etc_root.create(&RelPath::new("services"), VfsNodeType::File)?;
+    etc_root.create(
+        &RelPath::new("services"),
+        VfsNodeType::File,
+        VfsNodePerm::default_file(),
+    )?;
     let file_services = etc_root.clone().lookup(&RelPath::new("services"))?;
     file_services.write_at(0, b"ssh		22/tcp")?;
 
     // Create /etc/resolv.conf
-    etc_root.create(&RelPath::new("resolv.conf"), VfsNodeType::File)?;
+    etc_root.create(
+        &RelPath::new("resolv.conf"),
+        VfsNodeType::File,
+        VfsNodePerm::default_file(),
+    )?;
     let file_resolv = etc_root.clone().lookup(&RelPath::new("resolv.conf"))?;
     file_resolv.write_at(
         0,

--- a/modules/ruxtask/src/vma.rs
+++ b/modules/ruxtask/src/vma.rs
@@ -58,11 +58,12 @@ used_fs! {
 #[cfg(feature = "fs")]
 fn open_swap_file(filename: &str) -> Arc<File> {
     use crate::fs::absolute_path;
+    use axfs_vfs::VfsNodePerm;
     use ruxfdtable::OpenFlags;
 
     let opt = OpenFlags::O_RDWR | OpenFlags::O_APPEND | OpenFlags::O_CREAT;
     let path = absolute_path(filename).unwrap();
-    ruxfs::fops::open_file_like(&path, opt)
+    ruxfs::fops::open_file_like(&path, opt, VfsNodePerm::default_file())
         .expect("create swap file failed")
         .into_any()
         .downcast::<File>()

--- a/ulib/ruxmusl/src/aarch64/mod.rs
+++ b/ulib/ruxmusl/src/aarch64/mod.rs
@@ -66,6 +66,12 @@ pub fn syscall(syscall_id: SyscallId, args: [usize; 6]) -> isize {
                 args[2] as c_int,
             ) as _,
             #[cfg(feature = "fs")]
+            SyscallId::FCHMODAT => ruxos_posix_api::sys_fchmodat(
+                args[0] as c_int,
+                args[1] as *const core::ffi::c_char,
+                args[2] as ctypes::mode_t,
+            ) as _,
+            #[cfg(feature = "fs")]
             SyscallId::FCHOWNAT => ruxos_posix_api::sys_fchownat(
                 args[0] as c_int,
                 args[1] as *const core::ffi::c_char,

--- a/ulib/ruxmusl/src/aarch64/syscall_id.rs
+++ b/ulib/ruxmusl/src/aarch64/syscall_id.rs
@@ -38,6 +38,8 @@ pub enum SyscallId {
     #[cfg(feature = "fs")]
     CHDIR = 49,
     #[cfg(feature = "fs")]
+    FCHMODAT = 53,
+    #[cfg(feature = "fs")]
     FCHOWNAT = 54,
     #[cfg(feature = "fs")]
     OPENAT = 56,


### PR DESCRIPTION
- Implement persistent mode storage in filesystem metadata
- Add proper handling for mode in openat(), fchmodat(), mkdirat(), mknodat() syscalls
- Remove temporary default mode generation in getattr()

There is a testcase:
```c
#include <dirent.h>
#include <fcntl.h>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <sys/stat.h>
#include <unistd.h>

/**​
 * Verify file permissions against expected value
 * @param dir_fd Directory file descriptor
 * @param filename Filename to check
 * @param expected Expected permissions (octal, e.g. 0644)
 */
void check_perms(int dir_fd, const char *filename, mode_t expected)
{
    struct stat st;
    // Use fstatat to get file status, avoiding path resolution issues
    if (fstatat(dir_fd, filename, &st, 0) == -1) {
        perror("fstatat");
        exit(EXIT_FAILURE);
    }
    mode_t perms = st.st_mode & 0777; // Extract permission bits
    if (perms != expected) {
        fprintf(stderr, "Error: File '%s' has permissions %03o, expected %03o\n", filename, perms,
                expected);
        exit(EXIT_FAILURE);
    }
    printf("Success: File '%s' permissions are %03o (matches expected %03o)\n", filename, perms,
           expected);
}

int main()
{
    // Create temporary directory
    char temp_dir[] = "testdir_XXXXXX";
    if (!mkdtemp(temp_dir)) {
        perror("mkdtemp failed");
        exit(EXIT_FAILURE);
    }
    printf("Created temp directory: %s\n", temp_dir);

    // Open directory file descriptor
    int dir_fd = open(temp_dir, O_RDONLY | O_DIRECTORY);
    if (dir_fd == -1) {
        perror("Failed to open directory");
        rmdir(temp_dir);
        exit(EXIT_FAILURE);
    }

    // Test Case 1: umask=0, verify openat mode setting
    printf("\nTest Case 1: umask=0, create file with 0777 via openat\n");
    mode_t old_umask = umask(0); // Set umask to 0 and save original
    const char *filename1 = "test1";
    int fd = openat(dir_fd, filename1, O_CREAT | O_RDWR, 0777);
    if (fd == -1) {
        perror("openat failed");
        goto cleanup;
    }
    close(fd);
    check_perms(dir_fd, filename1, 0777); // Expected 0777
    umask(old_umask);                     // Restore original umask

    // Test Case 2: umask=022, verify openat mode filtering
    printf("\nTest Case 2: umask=022, create file with 0777 via openat\n");
    umask(022); // Set umask to 022
    const char *filename2 = "test2";
    fd = openat(dir_fd, filename2, O_CREAT | O_RDWR, 0777);
    if (fd == -1) {
        perror("openat failed");
        goto cleanup;
    }
    close(fd);
    check_perms(dir_fd, filename2, 0755); // Expected 0755 (0777 & ~022)
    umask(0);                             // Reset umask for subsequent tests

    // Test Case 3: Verify fchmodat permission modification
    printf("\nTest Case 3: Modify permissions to 0644 using fchmodat\n");
    const char *filename3 = "test3";
    fd = openat(dir_fd, filename3, O_CREAT | O_RDWR, 0777);
    if (fd == -1) {
        perror("openat failed");
        goto cleanup;
    }
    close(fd);
    // Modify permissions using fchmodat
    if (fchmodat(dir_fd, filename3, 0644, 0) == -1) {
        perror("fchmodat failed");
        goto cleanup;
    }
    check_perms(dir_fd, filename3, 0644); // Expected 0644

cleanup:
    // Cleanup: Remove test files and directory
    // printf("\nCleaning up temporary files...\n");
    // unlinkat(dir_fd, filename1, 0);
    // unlinkat(dir_fd, filename2, 0);
    // unlinkat(dir_fd, filename3, 0);
    // close(dir_fd);
    // if (rmdir(temp_dir) == -1) {
    //     perror("Failed to remove directory");
    //     return EXIT_FAILURE;
    // }
    // printf("Test completed, all resources cleaned up\n");
    printf("Test completed\n");
    return EXIT_SUCCESS;
}
```
The expected output will be:
```
Created temp directory: testdir_JONgbB

Test Case 1: umask=0, create file with 0777 via openat
Success: File 'test1' permissions are 777 (matches expected 777)

Test Case 2: umask=022, create file with 0777 via openat
Success: File 'test2' permissions are 755 (matches expected 755)

Test Case 3: Modify permissions to 0644 using fchmodat
Success: File 'test3' permissions are 644 (matches expected 644)
Test completed
```

It can run on both Ramfs and virtio-9p filesystems. When using virtio-9p, a folder named similarly to testdir_JONgbB will be generated in the root directory. If you check this directory's permissions on the host machine using ls -l, it will display the correct permissions:

```
 ~/fork/ruxos | on dev >1  ls -l /home/stone/fork/ruxos/apps/c/mode/rootfs/testdir_jdNIfG                                                                  ok | at 14:29:55 
total 0
-rwxrwxrwx 1 stone stone 0 Apr 10 14:28 test1
-rwxr-xr-x 1 stone stone 0 Apr 10 14:28 test2
-rw-r--r-- 1 stone stone 0 Apr 10 14:28 test3
```