### PR TITLE
fix(rename): correctly handle rename in struct RootDirectory

### DIFF
--- a/modules/ruxfs/src/root.rs
+++ b/modules/ruxfs/src/root.rs
@@ -185,9 +185,13 @@ impl VfsNodeOps for RootDirectory {
         if src_path.len() == src_len {
             return ax_err!(PermissionDenied); // cannot rename mount points
         }
-        self.mounts[src_idx].fs.root_dir().rename(
-            &RelPath::new_trimmed(&src_path[src_len..]),
-            &RelPath::new_trimmed(&dst_path[dst_len..]),
-        )
+        if src_len > 0 {
+            self.mounts[src_idx].fs.root_dir().rename(
+                &RelPath::new_trimmed(&src_path[src_len..]),
+                &RelPath::new_trimmed(&dst_path[dst_len..]),
+            )
+        } else {
+            self.main_fs.root_dir().rename(src_path, dst_path)
+        }
     }
 }


### PR DESCRIPTION
The following code won't run correctly without this fix
```c
#include <errno.h>
#include <fcntl.h>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <unistd.h>

/**
 * Function to test the rename system call
 *
 * @param oldname Original filename
 * @param newname New filename
 * @return 0 on success, -1 on failure
 */
int test_rename(const char *oldname, const char *newname)
{
    // Create test file
    int fd = open(oldname, O_CREAT | O_WRONLY, 0644);
    if (fd == -1) {
        perror("Failed to create test file");
        return -1;
    }
    close(fd);
    printf("Test file created: %s\n", oldname);

    // Attempt to rename file
    if (rename(oldname, newname) == -1) {
        perror("rename() call failed");
        unlink(oldname); // Clean up test file
        return -1;
    }
    printf("Successfully renamed %s to %s\n", oldname, newname);

    // Verify new file exists
    if (access(newname, F_OK) == -1) {
        printf("Error: New file %s does not exist\n", newname);
        return -1;
    }
    printf("Verification: New file %s exists\n", newname);

    // Verify old file no longer exists
    if (access(oldname, F_OK) == 0) {
        printf("Warning: Old file %s still exists\n", oldname);
        // This is not a fatal error, continue execution
    } else {
        printf("Verification: Old file %s no longer exists\n", oldname);
    }

    // Clean up test file
    if (unlink(newname) == -1) {
        perror("Failed to delete test file");
        return -1;
    }
    printf("Test file cleaned up: %s\n", newname);

    return 0;
}

int main()
{
    const char *oldname = "testfile.txt";
    const char *newname = "renamed_testfile.txt";

    printf("Starting rename system call test...\n");

    int result = test_rename(oldname, newname);

    if (result == 0) {
        printf("Test passed: rename system call works correctly\n");
    } else {
        printf("Test failed: rename system call has issues\n");
    }

    return result;
}
```
